### PR TITLE
Make embed color config env-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ MAX_IMAGE_BYTES_FOR_PROMPT="4194304" # Max size of image data for vision prompts
 MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT="8000" # Max length of scraped text to include in prompts
 STREAM_EDIT_THROTTLE_SECONDS="0.1" # How frequently to edit messages when streaming LLM responses
 EDITS_PER_SECOND="5" # Target edits per second for streaming (inverse of throttle)
+# Embed colors are hex integers (e.g., 0xEDA439 or #EDA439)
 EMBED_COLOR_INCOMPLETE="0xEDA439" # Embed color for in-progress messages
 EMBED_COLOR_COMPLETE="0x4CAF50" # Embed color for completed messages
 EMBED_COLOR_ERROR="0xF44336" # Embed color for error messages

--- a/config.py
+++ b/config.py
@@ -31,8 +31,30 @@ class Config:
         # Users should set complex preferences via the environment variable.
         self.SEARX_PREFERENCES = os.getenv("SEARX_PREFERENCES", "")
 
-        self.EMBED_COLOR = {"incomplete": discord.Color.orange(), "complete": discord.Color.green(), "error": discord.Color.red()}
-        self.EMBED_MAX_LENGTH = 4096
+        def _parse_color(env_var: str, default: int) -> int:
+            value = os.getenv(env_var)
+            if value:
+                value = value.strip()
+                if value.startswith("#"):
+                    value = value[1:]
+                if value.lower().startswith("0x"):
+                    value = value[2:]
+                try:
+                    return int(value, 16)
+                except ValueError:
+                    pass
+            return default
+
+        self.EMBED_COLOR = {
+            "incomplete": _parse_color(
+                "EMBED_COLOR_INCOMPLETE", discord.Color.orange().value
+            ),
+            "complete": _parse_color(
+                "EMBED_COLOR_COMPLETE", discord.Color.green().value
+            ),
+            "error": _parse_color("EMBED_COLOR_ERROR", discord.Color.red().value),
+        }
+        self.EMBED_MAX_LENGTH = int(os.getenv("EMBED_MAX_LENGTH", 4096))
         self.EDITS_PER_SECOND = 1.3
         self.STREAM_EDIT_THROTTLE_SECONDS = float(os.getenv("STREAM_EDIT_THROTTLE_SECONDS", 0.1))
 


### PR DESCRIPTION
## Summary
- allow EMBED_COLOR_* and EMBED_MAX_LENGTH to be configured via env vars
- document configurable embed values

## Testing
- `python -m py_compile config.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f7381642c832899d70aff2d717a08