### PR TITLE
Fix logs and global use

### DIFF
--- a/audio_utils.py
+++ b/audio_utils.py
@@ -134,7 +134,6 @@ async def send_tts_audio( # Ensure this function is defined at the module level
         await _send_audio_segment(destination, text_to_speak, "full", is_thought=False, base_filename=base_filename)
 
 def transcribe_audio_file(file_path: str) -> Optional[str]:
-    global WHISPER_MODEL
     if not os.path.exists(file_path):
         logger.error(f"Audio file not found for transcription: {file_path}")
         return None

--- a/web_utils.py
+++ b/web_utils.py
@@ -222,8 +222,11 @@ async def scrape_latest_tweets(username_queried: str, limit: int = 10) -> List[D
     user_data_dir = os.path.join(os.getcwd(), ".pw-profile")
     profile_dir_usable = True
     if not os.path.exists(user_data_dir):
-        try: os.makedirs(user_data_dir, exist_ok=True)
-        except OSError: profile_dir_usable = False; logger.error(f"Could not create .pw-profile. Using non-persistent context for tweet scraping.")
+        try:
+            os.makedirs(user_data_dir, exist_ok=True)
+        except OSError:
+            profile_dir_usable = False
+            logger.error("Could not create .pw-profile. Using non-persistent context for tweet scraping.")
 
     context_manager: Optional[Any] = None
     browser_instance_st: Optional[Any] = None


### PR DESCRIPTION
## Summary
- fix f-string usage in web utils when creating profile directory
- remove unnecessary `global` from Whisper transcription function

## Testing
- `pyflakes $(git ls-files '*.py')`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f72c672d08328b3b591b6092838b8