### PR TITLE
Add Playwright headless and concurrency options

### DIFF
--- a/config.py
+++ b/config.py
@@ -70,6 +70,9 @@ class Config:
         
         self.NEWS_MAX_LINKS_TO_PROCESS = int(os.getenv("NEWS_MAX_LINKS_TO_PROCESS", 5))
 
+        self.HEADLESS_PLAYWRIGHT = os.getenv("HEADLESS_PLAYWRIGHT", "true").lower() == "true"
+        self.PLAYWRIGHT_MAX_CONCURRENCY = int(os.getenv("PLAYWRIGHT_MAX_CONCURRENCY", 2))
+
 
 # Global config instance
 config = Config()

--- a/example.env
+++ b/example.env
@@ -45,3 +45,7 @@ EMBED_COLOR_COMPLETE="0x4CAF50" # Embed color for completed messages
 EMBED_COLOR_ERROR="0xF44336" # Embed color for error messages
 
 SEARX_PREFERENCES = long ass preference string can be found in searx settings, stores what search engines to use, etc.
+
+# Playwright settings
+HEADLESS_PLAYWRIGHT = true
+PLAYWRIGHT_MAX_CONCURRENCY = 2

--- a/open_chatgpt_login.py
+++ b/open_chatgpt_login.py
@@ -3,10 +3,11 @@ import os
 from typing import Optional
 
 from playwright.async_api import BrowserContext, async_playwright
+from config import config
 
 async def open_chatgpt_login():
     """
-    Launches a non-headless browser using a persistent context,
+    Launches a browser using a persistent context,
     navigates to the ChatGPT login page, and waits for the user to close it.
     This helps save the login session in the .pw-profile directory.
     """
@@ -35,7 +36,7 @@ async def open_chatgpt_login():
             # Using launch_persistent_context to save login state
             browser_context = await p.chromium.launch_persistent_context(
                 user_data_dir,
-                headless=False,  # Makes the browser visible
+                headless=config.HEADLESS_PLAYWRIGHT,
                 args=[
                     "--disable-blink-features=AutomationControlled",
                     # "--no-sandbox", # Uncomment if you run into sandbox issues, common in some environments

--- a/web_utils.py
+++ b/web_utils.py
@@ -17,7 +17,7 @@ from config import config
 
 logger = logging.getLogger(__name__)
 
-PLAYWRIGHT_SEM = asyncio.Semaphore(2) 
+PLAYWRIGHT_SEM = asyncio.Semaphore(config.PLAYWRIGHT_MAX_CONCURRENCY)
 
 JS_EXPAND_SHOWMORE_TWITTER = """
 (maxClicks) => {
@@ -132,15 +132,15 @@ async def scrape_website(url: str) -> Optional[str]:
             async with async_playwright() as p:
                 if profile_dir_usable:
                     context = await p.chromium.launch_persistent_context(
-                        user_data_dir, 
-                        headless=False, 
+                        user_data_dir,
+                        headless=config.HEADLESS_PLAYWRIGHT,
                         args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"], 
                         user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36" 
                     )
                 else: 
                     logger.warning("Using non-persistent context for scrape_website due to profile directory issue.")
                     browser_instance_sw = await p.chromium.launch(
-                        headless=False, 
+                        headless=config.HEADLESS_PLAYWRIGHT,
                         args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"]
                     )
                     context = await browser_instance_sw.new_context(
@@ -236,7 +236,7 @@ async def scrape_latest_tweets(username_queried: str, limit: int = 10) -> List[D
             async with async_playwright() as p:
                 if profile_dir_usable:
                     context = await p.chromium.launch_persistent_context(
-                        user_data_dir, headless=False,
+                        user_data_dir, headless=config.HEADLESS_PLAYWRIGHT,
                         args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
                         user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36",
                         slow_mo=150 
@@ -244,7 +244,7 @@ async def scrape_latest_tweets(username_queried: str, limit: int = 10) -> List[D
                 else:
                     logger.warning("Using non-persistent context for tweet scraping.")
                     browser_instance_st = await p.chromium.launch(
-                        headless=False, 
+                        headless=config.HEADLESS_PLAYWRIGHT,
                         args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
                         slow_mo=150
                     )


### PR DESCRIPTION
## Summary
- support HEADLESS_PLAYWRIGHT and PLAYWRIGHT_MAX_CONCURRENCY settings
- use config options for Playwright launch calls
- document new variables in example.env

## Testing
- `python -m py_compile config.py web_utils.py open_chatgpt_login.py`

------
https://chatgpt.com/codex/tasks/task_e_683f8017ecc8832887c84ce7e98aeee0