### PR TITLE
Move bot token check to helper

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,8 +7,9 @@ class Config:
     def __init__(self):
         load_dotenv()
         self.DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
-        if not self.DISCORD_BOT_TOKEN:
-            raise ValueError("DISCORD_BOT_TOKEN environment variable is missing")
+        # Token validation moved to ``require_bot_token`` so that modules which
+        # don't need the bot token (e.g. ``open_chatgpt_login.py``) can import
+        # the configuration without raising an exception.
 
         self.LOCAL_SERVER_URL = os.getenv("LOCAL_SERVER_URL", "http://localhost:1234/v1")
         self.LLM_MODEL = os.getenv("LLM", "local-model")
@@ -76,3 +77,10 @@ class Config:
 
 # Global config instance
 config = Config()
+
+
+def require_bot_token() -> str:
+    """Return the Discord bot token or raise if it's missing."""
+    if not config.DISCORD_BOT_TOKEN:
+        raise ValueError("DISCORD_BOT_TOKEN environment variable is missing")
+    return config.DISCORD_BOT_TOKEN

--- a/main_bot.py
+++ b/main_bot.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 from openai import AsyncOpenAI # Using the direct import
 
 # Import configurations and state
-from config import config # Imports the global 'config' instance
+from config import config, require_bot_token  # ``require_bot_token`` enforces that the bot token is set
 from state import BotState # Assuming state.py is in the same directory
 
 # Import utility and manager modules
@@ -48,9 +48,13 @@ bot_state = BotState()
 # --- Main Execution Block ---
 if __name__ == "__main__":
     # Validate essential configurations before trying to run
-    if not config.DISCORD_BOT_TOKEN:
-        logger.critical("DISCORD_BOT_TOKEN is not set in the environment or .env file. Bot cannot start.")
-        exit(1) # Exit if token is missing
+    try:
+        bot_token = require_bot_token()
+    except ValueError:
+        logger.critical(
+            "DISCORD_BOT_TOKEN is not set in the environment or .env file. Bot cannot start."
+        )
+        exit(1)
 
     # Initialize ChromaDB
     # This function now resides in rag_chroma_manager and sets up global chroma clients there
@@ -77,7 +81,7 @@ if __name__ == "__main__":
     try:
         logger.info("Starting Discord bot...")
         # log_handler=None prevents discord.py from setting up its own root logger if we've already configured one.
-        bot.run(config.DISCORD_BOT_TOKEN, log_handler=None) 
+        bot.run(bot_token, log_handler=None)
     except discord.LoginFailure:
         logger.critical("Failed to log in to Discord. Check the DISCORD_BOT_TOKEN.")
     except Exception as e:

--- a/open_chatgpt_login.py
+++ b/open_chatgpt_login.py
@@ -3,6 +3,7 @@ import os
 from typing import Optional
 
 from playwright.async_api import BrowserContext, async_playwright
+# Import configuration; bot token isn't required for this utility script
 from config import config
 
 async def open_chatgpt_login():


### PR DESCRIPTION
## Summary
- load configuration without verifying the bot token
- add `require_bot_token()` helper in `config.py`
- use the helper in `main_bot.py`
- clarify token is not needed for `open_chatgpt_login.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f9cf632c88328925b9b569a532c94