### PR TITLE
Use async context manager for persistent Playwright context

### DIFF
--- a/open_chatgpt_login.py
+++ b/open_chatgpt_login.py
@@ -1,8 +1,7 @@
 import asyncio
 import os
-from typing import Optional
 
-from playwright.async_api import BrowserContext, async_playwright
+from playwright.async_api import async_playwright
 from config import config
 
 async def open_chatgpt_login():
@@ -31,10 +30,9 @@ async def open_chatgpt_login():
         return
 
     async with async_playwright() as p:
-        browser_context: Optional[BrowserContext] = None
         try:
             # Using launch_persistent_context to save login state
-            browser_context = await p.chromium.launch_persistent_context(
+            async with (await p.chromium.launch_persistent_context(
                 user_data_dir,
                 headless=config.HEADLESS_PLAYWRIGHT,
                 args=[
@@ -43,33 +41,25 @@ async def open_chatgpt_login():
                     # "--disable-dev-shm-usage" # Can help in resource-constrained environments
                 ],
                 slow_mo=100  # Slows down Playwright operations to make it easier to see
-            )
-            
-            page = await browser_context.new_page()
-            
-            print("Navigating to ChatGPT (chat.openai.com)...")
-            # Navigate to the main chat page, which will redirect to login if not authenticated
-            await page.goto("https://chat.openai.com/", wait_until="networkidle", timeout=120000)
-            
-            print("\n-------------------------------------------------------------------------")
-            print("Browser is open. Please log in to ChatGPT in this window if prompted.")
-            print("Once you have logged in and the main chat interface has loaded,")
-            print("you can close the browser window.")
-            print("Your login session should be saved in the '.pw-profile' directory.")
-            print("-------------------------------------------------------------------------")
-            
-            # Keep the script running until the browser context is closed by the user
-            await browser_context.wait_for_event("close")
-            print("Browser closed by user. Session (if login was successful) should be saved.")
+            )) as browser_context:
+
+                page = await browser_context.new_page()
+
+                print("Navigating to ChatGPT (chat.openai.com)...")
+                # Navigate to the main chat page, which will redirect to login if not authenticated
+                await page.goto("https://chat.openai.com/", wait_until="networkidle", timeout=120000)
+                print("\n-------------------------------------------------------------------------")
+                print("Browser is open. Please log in to ChatGPT in this window if prompted.")
+                print("Once you have logged in and the main chat interface has loaded,")
+                print("you can close the browser window.")
+                print("Your login session should be saved in the '.pw-profile' directory.")
+                print("-------------------------------------------------------------------------")
+                # Keep the script running until the browser context is closed by the user
+                await browser_context.wait_for_event("close")
+                print("Browser closed by user. Session (if login was successful) should be saved.")
 
         except Exception as e:
             print(f"An error occurred: {e}")
-        finally:
-            if browser_context:
-                try:
-                    await browser_context.close()
-                except Exception as e_close:
-                    print(f"Error closing browser context: {e_close}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use an async context manager when launching the persistent Playwright context
- drop manual BrowserContext close logic

## Testing
- `python3 -m py_compile open_chatgpt_login.py`
- `python3 open_chatgpt_login.py` *(fails to navigate due to cert error)*
- `ps -ef | grep -i chromium`

------
https://chatgpt.com/codex/tasks/task_e_683f9cd7f7a08328b268c8af5c3b6464