### PR TITLE
Use awaited context for persistent login

### DIFF
--- a/open_chatgpt_login.py
+++ b/open_chatgpt_login.py
@@ -1,8 +1,7 @@
 import asyncio
 import os
-from typing import Optional
 
-from playwright.async_api import BrowserContext, async_playwright
+from playwright.async_api import async_playwright
 # Import configuration; bot token isn't required for this utility script
 from config import config
 
@@ -32,45 +31,52 @@ async def open_chatgpt_login():
         return
 
     async with async_playwright() as p:
-        browser_context: Optional[BrowserContext] = None
         try:
-            # Using launch_persistent_context to save login state
-            browser_context = await p.chromium.launch_persistent_context(
+            # Using launch_persistent_context to save login state. Await the
+            # coroutine first so the returned BrowserContext can be used as an
+            # async context manager.
+            async with await p.chromium.launch_persistent_context(
                 user_data_dir,
-                headless=config.HEADLESS_PLAYWRIGHT,
+                headless=False,
                 args=[
                     "--disable-blink-features=AutomationControlled",
                     # "--no-sandbox", # Uncomment if you run into sandbox issues, common in some environments
                     # "--disable-dev-shm-usage" # Can help in resource-constrained environments
                 ],
                 slow_mo=100  # Slows down Playwright operations to make it easier to see
-            )
-            
-            page = await browser_context.new_page()
-            
-            print("Navigating to ChatGPT (chat.openai.com)...")
-            # Navigate to the main chat page, which will redirect to login if not authenticated
-            await page.goto("https://chat.openai.com/", wait_until="networkidle", timeout=120000)
-            
-            print("\n-------------------------------------------------------------------------")
-            print("Browser is open. Please log in to ChatGPT in this window if prompted.")
-            print("Once you have logged in and the main chat interface has loaded,")
-            print("you can close the browser window.")
-            print("Your login session should be saved in the '.pw-profile' directory.")
-            print("-------------------------------------------------------------------------")
-            
-            # Keep the script running until the browser context is closed by the user
-            await browser_context.wait_for_event("close")
-            print("Browser closed by user. Session (if login was successful) should be saved.")
+            ) as browser_context:
+                page = await browser_context.new_page()
+                
+                print("Navigating to ChatGPT (chat.openai.com)...")
+                # Navigate to the main chat page, which will redirect to login if not authenticated
+                await page.goto("https://chat.openai.com/", wait_until="networkidle", timeout=120000)
+                
+                print("\n-------------------------------------------------------------------------")
+                print("Browser is open. Please log in to ChatGPT in this window if prompted.")
+                print("Once you have logged in and the main chat interface has loaded,")
+                print("you can close the browser window.")
+                print("Your login session should be saved in the '.pw-profile' directory.")
+                print("-------------------------------------------------------------------------")
+                
+                # Keep the script running until the browser context is closed by the user
+                await browser_context.wait_for_event("close")
+                print("Browser closed by user. Session (if login was successful) should be saved.")
 
         except Exception as e:
             print(f"An error occurred: {e}")
         finally:
-            if browser_context:
-                try:
-                    await browser_context.close()
-                except Exception as e_close:
-                    print(f"Error closing browser context: {e_close}")
+            # After context exit, verify no lingering Chromium processes
+            proc = await asyncio.create_subprocess_shell(
+                "pgrep -f chromium || true",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            if stdout.strip():
+                print("Warning: Chromium processes may still be running:")
+                print(stdout.decode().strip())
+            else:
+                print("No lingering Chromium processes detected.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix `async with` usage when launching the persistent browser context

## Testing
- `python -m py_compile open_chatgpt_login.py`
- `timeout 7s python open_chatgpt_login.py` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_683f9f8b2b9c83288c8c03b41b09ed87