### PR TITLE
Use uuid4 for doc IDs

### DIFF
--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -1,5 +1,5 @@
 import logging
-import random
+from uuid import uuid4
 from datetime import datetime
 from typing import List, Optional, Any, Dict, Union
 import json
@@ -241,7 +241,7 @@ async def ingest_conversation_to_chromadb(
 
     timestamp_now = datetime.now()
     str_user_id = str(user_id) 
-    full_convo_doc_id = f"full_channel_{channel_id}_user_{str_user_id}_{int(timestamp_now.timestamp())}_{random.randint(1000,9999)}"
+    full_convo_doc_id = f"full_channel_{channel_id}_user_{str_user_id}_{int(timestamp_now.timestamp())}_{uuid4().hex}"
     
     full_convo_metadata: Dict[str, Any] = {
         "channel_id": str(channel_id), "user_id": str_user_id, "timestamp": timestamp_now.isoformat(),
@@ -447,7 +447,7 @@ async def store_chatgpt_conversations_in_chromadb(llm_client: Any, conversations
 
         timestamp = convo_data.get('create_time', datetime.now()) 
         safe_title = re.sub(r'\W+', '_', convo_data.get('title', 'untitled'))[:50] 
-        full_convo_doc_id = f"{source}_full_{safe_title}_{i}_{int(timestamp.timestamp())}_{random.randint(1000,9999)}"
+        full_convo_doc_id = f"{source}_full_{safe_title}_{i}_{int(timestamp.timestamp())}_{uuid4().hex}"
         
         full_convo_metadata: Dict[str, Any] = {  
             "title": convo_data.get('title', 'Untitled'), 


### PR DESCRIPTION
## Summary
- switch conversation ID generation from `random.randint` to `uuid4().hex`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fae652cc0832889df5a8c86f0aef5