### PR TITLE
Add robust env parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
 
 ### Key Environment Variables
 
-Some of the most important settings you can tweak via the `.env` file are listed below. Refer to `config.py` and `example.env` for defaults and additional options.
+Some of the most important settings you can tweak via the `.env` file are listed below. Refer to `config.py` and `example.env` for defaults and additional options. Numeric values must be valid integers (or floats where noted) and booleans should be expressed as `true` or `false` (case-insensitive).
 
 * `DISCORD_BOT_TOKEN` – token for your Discord bot.
 * `LOCAL_SERVER_URL` – base URL of the OpenAI-compatible LLM server.

--- a/example.env
+++ b/example.env
@@ -16,10 +16,13 @@ LLM = qwen3-30b-a3b
 
 VISION_LLM_MODEL = gemma-3-4b-it
 
+# Numeric values must be valid integers (or floats where noted).
+# Boolean values accept "true" or "false" (case-insensitive).
+
 # TTS configuration
 TTS_API_URL = http://localhost:8880/v1/audio/speech
 TTS_VOICE = af_sky+af+af_nicole
-TTS_ENABLED_DEFAULT = true
+TTS_ENABLED_DEFAULT = true # true or false
 
 CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
 
@@ -61,5 +64,5 @@ STREAM_EDIT_THROTTLE_SECONDS = 0.1
 SEARX_PREFERENCES = long ass preference string can be found in searx settings, stores what search engines to use, etc.
 
 # Playwright settings
-HEADLESS_PLAYWRIGHT = true
+HEADLESS_PLAYWRIGHT = true # true or false
 PLAYWRIGHT_MAX_CONCURRENCY = 2


### PR DESCRIPTION
## Summary
- add helper functions to parse ints, floats and booleans with warnings
- handle invalid env vars with fallbacks in `config.py`
- log invalid color values
- document valid formats in README and example.env

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fbcb44d34832887a696f62cb0c420