### PR TITLE
Improve scraping robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
 *   **Intelligent Conversations:** Powered by local LLMs (e.g., LM Studio, Ollama compatible), allowing for nuanced and context-aware dialogue.
 *   **Long-Term Memory (RAG):** Utilizes ChromaDB to store and retrieve conversation history, enabling the bot to recall past interactions and provide more informed responses. Conversations are "distilled" into keyword-rich sentences for efficient semantic search.
 *   **Web Capabilities:**
-    *   Scrape website content and YouTube transcripts.
+    *   Scrape website content and YouTube transcripts. If Playwright yields little text, the bot falls back to a simple BeautifulSoup request with a Googlebot user agent.
     *   Perform web searches (optionally via a local SearXNG instance) and summarize results.
     *   Fetch and summarize recent tweets from X/Twitter users.
 *   **Multimedia Interaction:**
@@ -41,6 +41,7 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
 *   **OpenAI API (compatible):** Standard interface for interacting with local Large Language Models.
 *   **ChromaDB:** An open-source vector database used for implementing Retrieval Augmented Generation (RAG) for long-term memory.
 *   **Playwright:** A library for browser automation, used here for web scraping capabilities.
+*   **BeautifulSoup:** Lightweight HTML parsing for fallback scraping when Playwright results are sparse.
 *   **Whisper (OpenAI):** A state-of-the-art speech-to-text model for audio transcription.
 *   **Asyncio:** Python's framework for asynchronous programming, crucial for a responsive Discord bot.
 *   **Supporting LLM Servers (Examples):** LM Studio, Ollama (these run the actual language models).
@@ -103,6 +104,7 @@ Some of the most important settings you can tweak via the `.env` file are listed
 * `RAG_NUM_DISTILLED_SENTENCES_TO_FETCH` – how many distilled sentences to include from history.
 * `MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT` – limit for scraped text added to prompts.
 * `NEWS_MAX_LINKS_TO_PROCESS` – number of news links to read with `/gettweets`.
+* `SCRAPE_SCROLL_ATTEMPTS` – how many times to scroll when scraping a webpage to load dynamic content.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -119,6 +119,7 @@ class Config:
 
         self.HEADLESS_PLAYWRIGHT = _get_bool("HEADLESS_PLAYWRIGHT", True)
         self.PLAYWRIGHT_MAX_CONCURRENCY = _get_int("PLAYWRIGHT_MAX_CONCURRENCY", 2)
+        self.SCRAPE_SCROLL_ATTEMPTS = _get_int("SCRAPE_SCROLL_ATTEMPTS", 3)
 
 
 # Global config instance

--- a/example.env
+++ b/example.env
@@ -66,3 +66,4 @@ SEARX_PREFERENCES = long ass preference string can be found in searx settings, s
 # Playwright settings
 HEADLESS_PLAYWRIGHT = true # true or false
 PLAYWRIGHT_MAX_CONCURRENCY = 2
+SCRAPE_SCROLL_ATTEMPTS = 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,9 @@ openai>=1.3.0
 aiohttp>=3.8.0
 pydub>=0.25.0
 
+# HTML parsing fallback
+beautifulsoup4>=4.12.2
+
 # Whisper speech-to-text (choose one, usually openai-whisper)
 
 openai-whisper>=20231117


### PR DESCRIPTION
## Summary
- add BeautifulSoup fallback for scrape_website when Playwright yields little content
- document fallback behavior
- list BeautifulSoup in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683fbfdcd09c8328997b2c79a195a56a