### PR TITLE
Fix missing random import

### DIFF
--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List, Optional, Any, Dict, Union
 import json
 import re
+import random
 
 
 import chromadb 


### PR DESCRIPTION
## Summary
- ensure `random` is imported for IDs in `store_news_summary`

## Testing
- `python -m py_compile rag_chroma_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc906e08483289c4892fb6c449c35