### PR TITLE
Add collection stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
     *   `/ingest_chatgpt_export`: Import conversations from a ChatGPT export file into the bot's long-term memory (ChromaDB).
 *   **High Configurability:** Most settings are managed via a `.env` file, allowing for easy customization of LLM endpoints, API keys, and bot behavior.
 *   **Modular Codebase:** Refactored into multiple Python files for better organization, maintainability, and scalability.
+*   **Collection Metrics:** Run `timeline_pruner.py --stats` to view counts and age distribution of stored documents.
 
 ---
 


### PR DESCRIPTION
## Summary
- report document counts and age distribution for each ChromaDB collection
- expose metrics via `--stats` flag on `timeline_pruner.py`
- document the new metrics option

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845479cdb1c8328875247be3e3ca2cc