### PR TITLE
Fix timeline pruner metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
 *   **High Configurability:** Most settings are managed via a `.env` file, allowing for easy customization of LLM endpoints, API keys, and bot behavior.
 *   **Modular Codebase:** Refactored into multiple Python files for better organization, maintainability, and scalability.
 
+*   **Collection Metrics:** Run `timeline_pruner.py --stats` to view counts and age distribution of stored documents.
+
+## Timeline Pruner & Metrics
+
+The `timeline_pruner.py` tool helps manage the size of your ChromaDB collections.
+Run it periodically to remove older items while preserving useful summaries.
+
+```bash
+python timeline_pruner.py --days 30
+```
+
+The above command prunes documents older than 30 days and stores a single summary for each day.
+
+To inspect your database without pruning, use the `--stats` flag:
+
+```bash
+python timeline_pruner.py --stats
+```
+
+This prints a count of documents for each collection along with how many entries were created in each month, e.g. `2024-05: 1200`.
+
 ---
 
 ## 3. Key Technologies Used

--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -7,12 +7,7 @@ from typing import Any, Dict, List
 from openai import AsyncOpenAI
 
 from config import config
-from rag_chroma_manager import (
-    initialize_chromadb,
-    chat_history_collection,
-    timeline_summary_collection,
-    synthesize_retrieved_contexts_llm,
-)
+import rag_chroma_manager as rcm
 
 logger = logging.getLogger(__name__)
 
@@ -20,19 +15,19 @@ PRUNE_DAYS = getattr(config, "TIMELINE_PRUNE_DAYS", 30)
 
 
 def _fetch_old_documents(prune_days: int) -> List[Dict[str, Any]]:
-    if not chat_history_collection:
+    if not rcm.chat_history_collection:
         logger.warning("Chat history collection unavailable")
         return []
 
     cutoff = datetime.now() - timedelta(days=prune_days)
     cutoff_iso = cutoff.isoformat()
 
-    total = chat_history_collection.count()
+    total = rcm.chat_history_collection.count()
     limit = 100
     old_docs: List[Dict[str, Any]] = []
 
     for offset in range(0, total, limit):
-        res = chat_history_collection.get(limit=limit, offset=offset, include=["documents", "metadatas", "ids"])
+        res = rcm.chat_history_collection.get(limit=limit, offset=offset, include=["documents", "metadatas", "ids"])
         ids = res.get("ids", [])
         docs = res.get("documents", [])
         metas = res.get("metadatas", [])
@@ -57,7 +52,7 @@ def _group_by_day(docs: List[Dict[str, Any]]):
 
 
 def _store_timeline_summary(start: datetime, end: datetime, summary: str, source_ids: List[str]):
-    if not timeline_summary_collection:
+    if not rcm.timeline_summary_collection:
         logger.warning("Timeline summary collection unavailable")
         return
     from uuid import uuid4
@@ -69,14 +64,70 @@ def _store_timeline_summary(start: datetime, end: datetime, summary: str, source
         "source_ids": source_ids,
     }
     try:
-        timeline_summary_collection.add(documents=[summary], metadatas=[metadata], ids=[doc_id])
+        rcm.timeline_summary_collection.add(documents=[summary], metadatas=[metadata], ids=[doc_id])
         logger.info(f"Stored timeline summary {doc_id} spanning {metadata['start']} to {metadata['end']}")
     except Exception as e:
         logger.error(f"Failed to store timeline summary: {e}")
 
 
+def _get_collection_timestamps(collection) -> List[datetime]:
+    """Retrieve timestamp metadata from all documents in a collection."""
+    total = collection.count()
+    limit = 100
+    timestamps: List[datetime] = []
+    for offset in range(0, total, limit):
+        res = collection.get(limit=limit, offset=offset, include=["metadatas"])
+        metas = res.get("metadatas", [])
+        for meta in metas:
+            ts_str = (meta or {}).get("timestamp") or (meta or {}).get("create_time")
+            if not ts_str:
+                continue
+            try:
+                ts = datetime.fromisoformat(ts_str)
+            except Exception:
+                continue
+            timestamps.append(ts)
+    return timestamps
+
+
+def print_collection_metrics() -> None:
+    """Log metrics about each ChromaDB collection."""
+    if not rcm.initialize_chromadb():
+        logger.error("ChromaDB initialization failed")
+        return
+
+    collections = [
+        ("chat_history_collection", rcm.chat_history_collection),
+        ("distilled_chat_summary_collection", rcm.distilled_chat_summary_collection),
+        ("news_summary_collection", rcm.news_summary_collection),
+        ("timeline_summary_collection", rcm.timeline_summary_collection),
+    ]
+
+    for name, coll in collections:
+        if not coll:
+            logger.info(f"Collection '{name}' unavailable")
+            continue
+
+        count = coll.count()
+        timestamps = _get_collection_timestamps(coll)
+
+        if timestamps:
+            earliest = min(timestamps)
+            latest = max(timestamps)
+            grouped = defaultdict(int)
+            for ts in timestamps:
+                grouped[ts.strftime("%Y-%m")] += 1
+            group_str = ", ".join(f"{m}: {c}" for m, c in sorted(grouped.items()))
+            logger.info(
+                f"Collection '{name}' has {count} docs. Oldest: {earliest.date()}, latest: {latest.date()}"
+            )
+            logger.info(f"    Counts by month: {group_str}")
+        else:
+            logger.info(f"Collection '{name}' has {count} docs (no timestamp metadata found)")
+
+
 async def prune_and_summarize(prune_days: int = PRUNE_DAYS):
-    if not initialize_chromadb():
+    if not rcm.initialize_chromadb():
         logger.error("ChromaDB initialization failed")
         return
 
@@ -94,11 +145,11 @@ async def prune_and_summarize(prune_days: int = PRUNE_DAYS):
         start = items[0]["timestamp"]
         end = items[-1]["timestamp"]
         query = f"Summarize chat history from {start.date()} to {end.date()} as a narrative"
-        summary = await synthesize_retrieved_contexts_llm(llm_client, texts, query)
+        summary = await rcm.synthesize_retrieved_contexts_llm(llm_client, texts, query)
         if summary:
             ids = [i["id"] for i in items]
             _store_timeline_summary(start, end, summary, ids)
-            chat_history_collection.delete(ids=ids)
+            rcm.chat_history_collection.delete(ids=ids)
             logger.info(f"Pruned {len(ids)} documents from {day}")
         else:
             logger.warning(f"No summary generated for {day}; skipping deletion")
@@ -115,6 +166,10 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Summarize and prune old chat history")
     parser.add_argument("--days", type=int, default=PRUNE_DAYS, help="Prune items older than this many days")
+    parser.add_argument("--stats", action="store_true", help="Print metrics about ChromaDB collections and exit")
     args = parser.parse_args()
 
-    asyncio.run(prune_and_summarize(args.days))
+    if args.stats:
+        print_collection_metrics()
+    else:
+        asyncio.run(prune_and_summarize(args.days))


### PR DESCRIPTION
## Summary
- ensure pruner module references collections from `rag_chroma_manager` after initialization
- document usage of the pruner in a new README section

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845479cdb1c8328875247be3e3ca2cc