### PR TITLE
Fix timeline pruning with latest ChromaDB

### DIFF
--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -27,7 +27,7 @@ def _fetch_old_documents(prune_days: int) -> List[Dict[str, Any]]:
     old_docs: List[Dict[str, Any]] = []
 
     for offset in range(0, total, limit):
-        res = rcm.chat_history_collection.get(limit=limit, offset=offset, include=["documents", "metadatas", "ids"])
+        res = rcm.chat_history_collection.get(limit=limit, offset=offset, include=["documents", "metadatas"])
         ids = res.get("ids", [])
         docs = res.get("documents", [])
         metas = res.get("metadatas", [])


### PR DESCRIPTION
## Summary
- remove deprecated `ids` include flag so `timeline_pruner.py` runs with recent versions of ChromaDB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454ea49a288328b487001d674779e9