### PR TITLE
Fix serialization when storing timeline summaries

### DIFF
--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -56,12 +56,16 @@ def _store_timeline_summary(start: datetime, end: datetime, summary: str, source
         logger.warning("Timeline summary collection unavailable")
         return
     from uuid import uuid4
+    import json
 
     doc_id = f"timeline_{int(start.timestamp())}_{int(end.timestamp())}_{uuid4().hex}"
+    # Serialize source_ids so the metadata values are primitive types for ChromaDB.
+    # To deserialize later, use json.loads(serialized_ids).
+    serialized_ids = json.dumps(source_ids)
     metadata = {
         "start": start.isoformat(),
         "end": end.isoformat(),
-        "source_ids": source_ids,
+        "source_ids": serialized_ids,
     }
     try:
         rcm.timeline_summary_collection.add(documents=[summary], metadatas=[metadata], ids=[doc_id])


### PR DESCRIPTION
## Summary
- serialize `source_ids` before storing timeline summaries in ChromaDB
- add comment describing the serialization/parse approach

## Testing
- `python -m py_compile timeline_pruner.py`
- `python - <<'PY'
import rag_chroma_manager as rcm
import sys, types
sys.modules['openai'] = types.SimpleNamespace(AsyncOpenAI=object)
import timeline_pruner as tp
from datetime import datetime
rcm.initialize_chromadb()
tp._store_timeline_summary(datetime.now(), datetime.now(), 'test summary', ['a','b'])
print('DONE')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6845517338f88328aaf762349797dc91