### PR TITLE
Fix collection metrics printing

### DIFF
--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -100,6 +100,10 @@ def print_collection_metrics() -> None:
         return
 
     collections = [
+        ("chat_history", rcm.chat_history_collection),
+        ("distilled", rcm.distilled_chat_summary_collection),
+        ("news", rcm.news_summary_collection),
+        ("timeline", rcm.timeline_summary_collection),
     ]
 
     for name, coll in collections:


### PR DESCRIPTION
## Summary
- populate the `collections` list in `print_collection_metrics` so metrics show for each ChromaDB collection

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68455c989c2083289bc436a2e3756085