### PR TITLE
Add archive.is fallback for paywalled URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Some of the most important settings you can tweak via the `.env` file are listed
 * `TTS_ENABLED_DEFAULT` – whether TTS is enabled by default.
 * `SEARX_URL` – URL of your SearXNG instance for `/search`.
 * `SEARX_PREFERENCES` – optional JSON string with engine preferences.
+* `PAYWALL_DOMAINS` – comma-separated list of domains to fetch via archive.is.
 * `CHROMA_DB_PATH` – location of the ChromaDB database directory.
 * `CHROMA_COLLECTION_NAME` – name of the collection for chat history.
 * `CHROMA_DISTILLED_COLLECTION_NAME` – name of the distilled summary collection.

--- a/config.py
+++ b/config.py
@@ -49,6 +49,10 @@ class Config:
                 except ValueError:
                     logger.warning("Invalid integer '%s' in %s; skipping", part, env_var)
             return values
+
+        def _parse_str_list(env_var: str) -> list[str]:
+            parts = os.getenv(env_var, "").split(",")
+            return [p.strip() for p in parts if p.strip()]
         self.DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
         # Token validation moved to ``require_bot_token`` so that modules which
         # don't need the bot token (e.g. ``open_chatgpt_login.py``) can import
@@ -111,6 +115,15 @@ class Config:
         self.CHROMA_TIMELINE_SUMMARY_COLLECTION_NAME = os.getenv("CHROMA_TIMELINE_SUMMARY_COLLECTION_NAME", "timeline_summaries")
         
         self.USER_PROVIDED_CONTEXT = os.getenv("USER_PROVIDED_CONTEXT", "")
+
+        self.PAYWALL_DOMAINS = _parse_str_list("PAYWALL_DOMAINS")
+        if not self.PAYWALL_DOMAINS:
+            self.PAYWALL_DOMAINS = [
+                "nytimes.com",
+                "washingtonpost.com",
+                "ft.com",
+                "wsj.com",
+            ]
 
         self.MAX_IMAGE_BYTES_FOR_PROMPT = _get_int("MAX_IMAGE_BYTES_FOR_PROMPT", 4 * 1024 * 1024)
         self.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT = _get_int("MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT", 8000)

--- a/example.env
+++ b/example.env
@@ -39,6 +39,7 @@ MAX_IMAGES_PER_MESSAGE = 1
 MAX_MESSAGE_HISTORY = 10
 
 SEARX_URL=http://192.168.1.3:9092/search
+PAYWALL_DOMAINS=nytimes.com,washingtonpost.com,ft.com,wsj.com
 
 CHROMA_DB_PATH = ./chroma_data
 


### PR DESCRIPTION
## Summary
- allow configuration of paywalled domains via `PAYWALL_DOMAINS`
- in `scrape_website`, route paywalled links through `https://archive.is/newest/`
- document new variable in README and example environment

## Testing
- `python -m py_compile config.py web_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_684998fb0664832884fa544f66c7f063