### PR TITLE
Handle CAPTCHA pages during scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Some of the most important settings you can tweak via the `.env` file are listed
 * `MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT` – limit for scraped text added to prompts.
 * `NEWS_MAX_LINKS_TO_PROCESS` – number of news links to read with `/gettweets`.
 * `SCRAPE_SCROLL_ATTEMPTS` – how many times to scroll when scraping a webpage to load dynamic content.
+* `HEADLESS_PLAYWRIGHT` – set to `false` if you need to manually solve web CAPTCHAs (opens a visible browser).
+* `PLAYWRIGHT_MAX_CONCURRENCY` – number of concurrent Playwright tasks allowed.
 
 ---
 


### PR DESCRIPTION
## Summary
- add helper `_detect_captcha` to check scraped pages for CAPTCHA text
- prompt the user to solve the CAPTCHA when running Playwright with a visible browser
- document Playwright configuration including CAPTCHA note

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849e06117408328a6690221cae2ab1c