### PR TITLE
feat: Implement tweet scrape progress and refined Playwright cleanup

### DIFF
--- a/config.py
+++ b/config.py
@@ -129,6 +129,10 @@ class Config:
         self.PLAYWRIGHT_MAX_CONCURRENCY = _get_int("PLAYWRIGHT_MAX_CONCURRENCY", 2)
         self.SCRAPE_SCROLL_ATTEMPTS = _get_int("SCRAPE_SCROLL_ATTEMPTS", 3)
 
+        # Configuration for Playwright cleanup task
+        self.PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES = _get_int("PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES", 5) # How often the cleanup task runs
+        self.PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES = _get_int("PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES", 10) # How long Playwright must be idle before cleanup
+
 
 # Global config instance
 config = Config()

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -2,20 +2,20 @@ import logging
 import discord
 from discord import app_commands # type: ignore
 from discord.ext import commands # For bot type hint
-import os 
-import base64 
-import random 
-from typing import Any, Optional, List
-from datetime import datetime 
+import os
+import base64
+import random
+from typing import Any, Optional, List # Keep existing imports
+from datetime import datetime
 
 # Bot services and utilities
-from config import config 
+from config import config
 from state import BotState
 from common_models import MsgNode
 
 from llm_handling import (
-    _build_initial_prompt_messages, 
-    stream_llm_response_to_interaction 
+    _build_initial_prompt_messages,
+    stream_llm_response_to_interaction
 )
 from rag_chroma_manager import (
     retrieve_and_prepare_rag_context,
@@ -24,11 +24,11 @@ from rag_chroma_manager import (
     store_news_summary,
 )
 from web_utils import (
-    scrape_website, 
-    query_searx, 
+    scrape_website,
+    query_searx,
     scrape_latest_tweets
 )
-from utils import parse_time_string_to_delta, chunk_text 
+from utils import parse_time_string_to_delta, chunk_text
 
 logger = logging.getLogger(__name__)
 
@@ -46,23 +46,27 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
 
     if not bot_instance or not llm_client_instance or not bot_state_instance:
         logger.critical("Bot, LLM client, or BotState not properly initialized in setup_commands. Commands may fail.")
-        return 
+        return
 
     @bot_instance.tree.command(name="news", description="Generates a news briefing on a given topic.")
     @app_commands.describe(
         topic="The news topic you want a briefing on."
     )
-    async def news_slash_command(interaction: discord.Interaction, topic: str): 
+    async def news_slash_command(interaction: discord.Interaction, topic: str):
         if not llm_client_instance or not bot_state_instance or not bot_instance or not bot_instance.user:
             logger.error("/news command: Bot components not ready.")
             await interaction.response.send_message("Bot components not ready. Cannot generate news.", ephemeral=True)
             return
 
         await interaction.response.defer(ephemeral=False)
-        
-        # Prepend "news " to the topic for the search query
+
+        # Update Playwright usage time (as per Step 3 of plan)
+        if bot_state_instance and hasattr(bot_state_instance, 'update_last_playwright_usage_time'):
+            bot_state_instance.update_last_playwright_usage_time()
+            logger.debug(f"Updated last_playwright_usage_time via bot_state_instance for /news command")
+
         search_topic = f"news {topic}"
-        
+
         initial_embed = discord.Embed(
             title=f"News Briefing: {topic}",
             description=f"Gathering news articles for '{search_topic}'...",
@@ -73,7 +77,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
         try:
             max_articles_to_process = config.NEWS_MAX_LINKS_TO_PROCESS
             logger.info(f"/news command for topic '{topic}' (searching for '{search_topic}') by {interaction.user.name}, max_articles={max_articles_to_process}")
-            
+
             search_results = await query_searx(search_topic)
 
             if not search_results:
@@ -105,14 +109,18 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                     color=config.EMBED_COLOR["incomplete"]
                 )
                 await interaction.edit_original_response(embed=update_embed)
-                
-                scraped_content = await scrape_website(article_url)
+
+                # Update Playwright usage time before each scrape
+                if bot_state_instance and hasattr(bot_state_instance, 'update_last_playwright_usage_time'):
+                    bot_state_instance.update_last_playwright_usage_time()
+
+                scraped_content = await scrape_website(article_url) # scrape_website uses Playwright
 
                 if not scraped_content or "Failed to scrape" in scraped_content or "Scraping timed out" in scraped_content:
                     logger.warning(f"Failed to scrape '{article_title}' from {article_url}. Reason: {scraped_content}")
                     article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: [Could not retrieve content for summarization]\n\n")
                     continue
-                
+
                 update_embed.description = f"Processing article {i+1}/{num_to_process}: Summarizing '{article_title}'..."
                 await interaction.edit_original_response(embed=update_embed)
 
@@ -122,22 +130,22 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                     f"news points and provide a concise summary (2-4 sentences) relevant to this topic. "
                     f"Focus on who, what, when, where, and why if applicable. Avoid opinions or speculation not present in the text.\n\n"
                     f"Article Title: {article_title}\n"
-                    f"Article Content:\n{scraped_content[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT*2]}" 
+                    f"Article Content:\n{scraped_content[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT*2]}"
                 )
-                
+
                 try:
                     summary_response = await llm_client_instance.chat.completions.create(
                         model=config.FAST_LLM_MODEL,
                         messages=[{"role": "user", "content": summarization_prompt}],
-                        max_tokens=250, 
-                        temperature=0.3, 
+                        max_tokens=250,
+                        temperature=0.3,
                         stream=False
                     )
                     if summary_response.choices and summary_response.choices[0].message and summary_response.choices[0].message.content:
                         article_summary = summary_response.choices[0].message.content.strip()
                         logger.info(f"Summarized '{article_title}': {article_summary[:100]}...")
                         article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
-                        
+
                         store_news_summary(topic=topic, url=article_url, summary_text=article_summary)
                     else:
                         logger.warning(f"LLM summarization returned no content for '{article_title}'.")
@@ -159,7 +167,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             await interaction.edit_original_response(embed=update_embed)
 
             combined_summaries_text = "".join(article_summaries_for_briefing)
-            
+
             final_briefing_prompt_content = (
                 f"You are Sam, a news anchor delivering a concise and objective briefing. "
                 f"The following are summaries of news articles related to the topic: '{topic}'. "
@@ -171,7 +179,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             )
 
             user_msg_node_for_briefing = MsgNode("user", final_briefing_prompt_content, name=str(interaction.user.id))
-            
+
             rag_query_for_briefing = f"news briefing about {topic}"
             synthesized_rag_context_for_briefing = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_for_briefing)
 
@@ -181,17 +189,17 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 bot_state=bot_state_instance,
                 user_id=str(interaction.user.id),
                 synthesized_rag_context_str=synthesized_rag_context_for_briefing,
-                max_image_history_depth=0 
+                max_image_history_depth=0
             )
 
             await stream_llm_response_to_interaction(
                 interaction=interaction,
                 llm_client=llm_client_instance,
                 bot_state=bot_state_instance,
-                user_msg_node=user_msg_node_for_briefing, 
+                user_msg_node=user_msg_node_for_briefing,
                 prompt_messages=prompt_nodes_for_briefing,
                 title=f"News Briefing: {topic}",
-                synthesized_rag_context_for_display=synthesized_rag_context_for_briefing, 
+                synthesized_rag_context_for_display=synthesized_rag_context_for_briefing,
                 bot_user_id=bot_instance.user.id
             )
 
@@ -202,38 +210,37 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 description=f"An unexpected error occurred while generating your news briefing: {str(e)[:1000]}",
                 color=config.EMBED_COLOR["error"]
             )
-            try: 
-                if interaction.response.is_done(): 
+            try:
+                if interaction.response.is_done():
                      await interaction.edit_original_response(embed=error_embed)
-                else: 
+                else:
                     await interaction.response.send_message(embed=error_embed, ephemeral=True)
-            except discord.HTTPException: 
+            except discord.HTTPException:
                 await interaction.followup.send(embed=error_embed, ephemeral=True)
-
 
 
     @bot_instance.tree.command(name="ingest_chatgpt_export", description="Ingests a conversations.json file from a ChatGPT export.")
     @app_commands.describe(file_path="The full local path to your conversations.json file.")
-    @app_commands.checks.has_permissions(manage_messages=True) 
+    @app_commands.checks.has_permissions(manage_messages=True)
     async def ingest_chatgpt_export_command(interaction: discord.Interaction, file_path: str):
         if not llm_client_instance:
             logger.error("ingest_chatgpt_export_command: llm_client_instance is None.")
             await interaction.response.send_message("LLM client not available. Cannot process.", ephemeral=True)
             return
 
-        await interaction.response.defer(ephemeral=True) 
+        await interaction.response.defer(ephemeral=True)
         logger.info(f"Ingestion of ChatGPT export file '{file_path}' initiated by {interaction.user.name} ({interaction.user.id}).")
-        
-        if not os.path.exists(file_path): 
+
+        if not os.path.exists(file_path):
             await interaction.followup.send(f"Error: File not found at the specified path: `{file_path}`", ephemeral=True)
             return
-        
+
         try:
-            parsed_conversations = parse_chatgpt_export(file_path) 
-            if not parsed_conversations: 
+            parsed_conversations = parse_chatgpt_export(file_path)
+            if not parsed_conversations:
                 await interaction.followup.send("Could not parse any conversations from the file. It might be empty or in an unexpected format.", ephemeral=True)
                 return
-            
+
             count = await store_chatgpt_conversations_in_chromadb(llm_client_instance, parsed_conversations)
             await interaction.followup.send(f"Successfully processed and stored {count} conversations (with distillations) from the export file into ChromaDB.", ephemeral=True)
         except Exception as e_ingest:
@@ -255,25 +262,25 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
     @bot_instance.tree.command(name="remindme", description="Sets a reminder. E.g., /remindme 1h30m Check the oven.")
     @app_commands.describe(time_duration="Duration (e.g., '10m', '2h30m', '1d').", reminder_message="The message for your reminder.")
     async def remindme_slash_command(interaction: discord.Interaction, time_duration: str, reminder_message: str):
-        if not bot_state_instance: 
+        if not bot_state_instance:
             logger.error("remindme_slash_command: bot_state_instance is None.")
             await interaction.response.send_message("Bot state not available. Cannot set reminder.", ephemeral=True)
             return
 
         time_delta, descriptive_time_str = parse_time_string_to_delta(time_duration)
-        
+
         if not time_delta or time_delta.total_seconds() <= 0:
             await interaction.response.send_message("Invalid time duration provided. Please use formats like '10m', '2h30m', '1d'.", ephemeral=True)
             return
-            
+
         reminder_time = datetime.now() + time_delta
-        if interaction.channel_id is None: 
+        if interaction.channel_id is None:
             await interaction.response.send_message("Error: Could not determine the channel for this reminder.", ephemeral=True)
             return
 
         reminder_entry = (reminder_time, interaction.channel_id, interaction.user.id, reminder_message, descriptive_time_str or "later")
-        await bot_state_instance.add_reminder(reminder_entry) 
-        
+        await bot_state_instance.add_reminder(reminder_entry)
+
         await interaction.response.send_message(f"Okay, {interaction.user.mention}! I'll remind you in {descriptive_time_str or 'the specified time'} about: \"{reminder_message}\"")
         logger.info(f"Reminder set for user {interaction.user.name} ({interaction.user.id}) at {reminder_time.strftime('%Y-%m-%d %H:%M:%S')} for: {reminder_message}")
 
@@ -284,39 +291,44 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             logger.error("roast_slash_command: One or more bot components (llm_client, bot_state, bot_instance) are None.")
             await interaction.response.send_message("Bot components not ready. Cannot perform roast.", ephemeral=True)
             return
-        
+
         logger.info(f"Roast command initiated by {interaction.user.name} for URL: {url}.")
-        if interaction.channel_id is None: 
+        if interaction.channel_id is None:
             await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
             return
-        
-        await interaction.response.defer(ephemeral=False) 
+
+        await interaction.response.defer(ephemeral=False)
+
+        # Update Playwright usage time (as per Step 3 of plan)
+        if bot_state_instance and hasattr(bot_state_instance, 'update_last_playwright_usage_time'):
+            bot_state_instance.update_last_playwright_usage_time()
+            logger.debug(f"Updated last_playwright_usage_time via bot_state_instance for /roast command")
 
         try:
-            webpage_text = await scrape_website(url) 
+            webpage_text = await scrape_website(url) # scrape_website uses Playwright
             if not webpage_text or "Failed to scrape" in webpage_text or "Scraping timed out" in webpage_text:
                 error_message = f"Sorry, I couldn't properly roast {url}. Reason: {webpage_text or 'Could not retrieve any content from the page.'}"
                 await interaction.followup.send(error_message, ephemeral=True)
                 return
-            
+
             user_query_content = f"Analyze the following content from the webpage {url} and write a short, witty, and biting comedy roast routine about it. Be creative and funny, focusing on absurdities or humorous angles. Do not just summarize. Make it a roast!\n\nWebpage Content:\n{webpage_text}"
             user_msg_node = MsgNode("user", user_query_content, name=str(interaction.user.id))
-            
+
             rag_query_for_roast = f"comedy roast of webpage content from URL: {url}"
             synthesized_rag_context = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_for_roast)
 
             prompt_nodes = await _build_initial_prompt_messages(
-                user_query_content=user_query_content, 
-                channel_id=interaction.channel_id, 
-                bot_state=bot_state_instance, 
+                user_query_content=user_query_content,
+                channel_id=interaction.channel_id,
+                bot_state=bot_state_instance,
                 user_id=str(interaction.user.id),
                 synthesized_rag_context_str=synthesized_rag_context
             )
             await stream_llm_response_to_interaction(
-                interaction, llm_client_instance, bot_state_instance, user_msg_node, prompt_nodes, 
+                interaction, llm_client_instance, bot_state_instance, user_msg_node, prompt_nodes,
                 title=f"Comedy Roast of {url}",
                 synthesized_rag_context_for_display=synthesized_rag_context,
-                bot_user_id=bot_instance.user.id 
+                bot_user_id=bot_instance.user.id
             )
         except Exception as e:
             logger.error(f"Error in roast_slash_command for URL '{url}': {e}", exc_info=True)
@@ -331,14 +343,14 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             return
 
         logger.info(f"Search command initiated by {interaction.user.name} for query: '{query}'.")
-        if interaction.channel_id is None: 
+        if interaction.channel_id is None:
             await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
             return
-        
-        await interaction.response.defer(ephemeral=False) 
+
+        await interaction.response.defer(ephemeral=False)
 
         try:
-            search_results = await query_searx(query)
+            search_results = await query_searx(query) # Does not use Playwright
             if not search_results:
                 await interaction.followup.send(f"Sorry, I couldn't find any search results for '{query}'.", ephemeral=True)
                 return
@@ -351,7 +363,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 content_str = str(content_raw) if content_raw is not None else 'No snippet available'
                 snippet_text = discord.utils.escape_markdown(content_str[:250])
                 snippets.append(f"{i+1}. **{title}** (<{url_link}>)\n   {snippet_text}...")
-            
+
             formatted_results = "\n\n".join(snippets)
             result_chunks = chunk_text(formatted_results, config.EMBED_MAX_LENGTH)
             for i, chunk in enumerate(result_chunks):
@@ -368,25 +380,25 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                     )
                 )
 
-            user_query_content_for_summary = f"Please analyze and concisely summarize the key information from these search results regarding the original query '{query}'. Focus on the most relevant points and synthesize them into a coherent overview. Do not just list the snippets. Provide a helpful summary.\n\nSearch Results:\n{formatted_results[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}" 
+            user_query_content_for_summary = f"Please analyze and concisely summarize the key information from these search results regarding the original query '{query}'. Focus on the most relevant points and synthesize them into a coherent overview. Do not just list the snippets. Provide a helpful summary.\n\nSearch Results:\n{formatted_results[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}"
             user_msg_node = MsgNode("user", user_query_content_for_summary, name=str(interaction.user.id))
-            
-            rag_query_for_search_summary = query 
-            synthesized_rag_context = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_for_search_summary) 
+
+            rag_query_for_search_summary = query
+            synthesized_rag_context = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_for_search_summary)
 
             prompt_nodes = await _build_initial_prompt_messages(
-                user_query_content=user_query_content_for_summary, 
+                user_query_content=user_query_content_for_summary,
                 channel_id=interaction.channel_id,
-                bot_state=bot_state_instance, 
+                bot_state=bot_state_instance,
                 user_id=str(interaction.user.id),
                 synthesized_rag_context_str=synthesized_rag_context
             )
             await stream_llm_response_to_interaction(
-                interaction, llm_client_instance, bot_state_instance, user_msg_node, prompt_nodes, 
-                title=f"Summary for Search: {query}", 
-                force_new_followup_flow=True, 
+                interaction, llm_client_instance, bot_state_instance, user_msg_node, prompt_nodes,
+                title=f"Summary for Search: {query}",
+                force_new_followup_flow=True,
                 synthesized_rag_context_for_display=synthesized_rag_context,
-                bot_user_id=bot_instance.user.id 
+                bot_user_id=bot_instance.user.id
             )
         except Exception as e:
             logger.error(f"Error in search_slash_command for query '{query}': {e}", exc_info=True)
@@ -404,7 +416,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
         if interaction.channel_id is None:
             await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
             return
-        
+
         await interaction.response.defer(ephemeral=False)
 
         try:
@@ -416,32 +428,32 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             )
             user_query_content = f"Generate a sarcastic comeback or commentary for the following political statement: \"{statement}\""
             user_msg_node = MsgNode("user", user_query_content, name=str(interaction.user.id))
-            
-            rag_query_for_pol = statement 
+
+            rag_query_for_pol = statement
             synthesized_rag_context = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_for_pol)
 
             base_prompt_nodes = await _build_initial_prompt_messages(
-                user_query_content=user_query_content, 
-                channel_id=interaction.channel_id, 
+                user_query_content=user_query_content,
+                channel_id=interaction.channel_id,
                 bot_state=bot_state_instance,
                 user_id=str(interaction.user.id),
                 synthesized_rag_context_str=synthesized_rag_context
             )
-            
+
             insert_idx = 0
             for idx, node in enumerate(base_prompt_nodes):
                 if node.role != "system":
                     insert_idx = idx
                     break
-                insert_idx = idx + 1 
-            
+                insert_idx = idx + 1
+
             final_prompt_nodes = base_prompt_nodes[:insert_idx] + [MsgNode("system", pol_system_content)] + base_prompt_nodes[insert_idx:]
-            
+
             await stream_llm_response_to_interaction(
-                interaction, llm_client_instance, bot_state_instance, user_msg_node, final_prompt_nodes, 
-                title="Sarcastic Political Commentary", 
+                interaction, llm_client_instance, bot_state_instance, user_msg_node, final_prompt_nodes,
+                title="Sarcastic Political Commentary",
                 synthesized_rag_context_for_display=synthesized_rag_context,
-                bot_user_id=bot_instance.user.id 
+                bot_user_id=bot_instance.user.id
             )
         except Exception as e:
             logger.error(f"Error in pol_slash_command for statement '{statement[:50]}...': {e}", exc_info=True)
@@ -456,81 +468,117 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             return
 
         logger.info(f"Gettweets command initiated by {interaction.user.name} for @{username}, limit {limit}.")
-        if interaction.channel_id is None: 
+        if interaction.channel_id is None:
             await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
             return
-            
-        await interaction.response.defer(ephemeral=False) 
+
+        await interaction.response.defer(ephemeral=False)
+
+        async def send_progress(message: str):
+            try:
+                # Send ephemeral followup messages for progress.
+                await interaction.followup.send(message, ephemeral=True)
+            except discord.HTTPException as e_prog:
+                logger.warning(f"Failed to send progress update for gettweets: {e_prog}")
 
         try:
             clean_username = username.lstrip('@')
-            tweets = await scrape_latest_tweets(clean_username, limit=limit)
-            
+
+            # Part of Step 3: Update last Playwright usage time
+            if bot_state_instance and hasattr(bot_state_instance, 'update_last_playwright_usage_time'):
+                bot_state_instance.update_last_playwright_usage_time()
+                logger.debug(f"Updated last_playwright_usage_time via bot_state_instance for /gettweets @{clean_username}")
+
+            await send_progress(f"Starting to scrape tweets for @{clean_username} (up to {limit})...")
+            tweets = await scrape_latest_tweets(clean_username, limit=limit, progress_callback=send_progress)
+
             if not tweets:
-                await interaction.followup.send(f"Could not fetch any recent tweets for @{clean_username}. The profile might be private, have no tweets, or there was an issue.", ephemeral=True)
+                # Send a final progress update if scraping finishes early or with no results
+                await send_progress(f"Finished scraping for @{clean_username}. No tweets found or profile might be private/inaccessible.")
+                await interaction.followup.send(f"Could not fetch any recent tweets for @{clean_username}. The profile might be private, have no tweets, or there was an issue. Scraping might have also been interrupted.", ephemeral=True)
                 return
 
             tweet_texts_for_display = []
             for t in tweets:
                 ts_str = t.get('timestamp', 'N/A')
                 display_ts = ts_str
-                try: 
+                try:
                     dt_obj = datetime.fromisoformat(ts_str.replace("Z", "+00:00")) if ts_str != 'N/A' else None
                     display_ts = dt_obj.strftime("%Y-%m-%d %H:%M UTC") if dt_obj else ts_str
-                except ValueError: pass 
+                except ValueError: pass
 
                 author_display = t.get('username', clean_username)
                 content_display = discord.utils.escape_markdown(t.get('content', 'N/A'))
                 tweet_url_display = t.get('tweet_url', '')
-                
+
                 header = f"[{display_ts}] @{author_display}"
                 if t.get('is_repost') and t.get('reposted_by'):
                     header = f"[{display_ts}] @{t.get('reposted_by')} reposted @{author_display}"
-                
+
                 link_text = f" ([Link]({tweet_url_display}))" if tweet_url_display else ""
                 tweet_texts_for_display.append(f"**{header}**: {content_display}{link_text}")
-            
+
             raw_tweets_display_str = "\n\n".join(tweet_texts_for_display)
             if not raw_tweets_display_str: raw_tweets_display_str = "No tweet content could be formatted for display."
-            
+
+            await send_progress(f"Formatting {len(tweets)} tweets for display...") # Final progress before showing results
+
             embed_title = f"Recent Tweets from @{clean_username}"
-            raw_tweet_chunks = chunk_text(raw_tweets_display_str, config.EMBED_MAX_LENGTH) 
-            
+            raw_tweet_chunks = chunk_text(raw_tweets_display_str, config.EMBED_MAX_LENGTH)
+
+            # Send the main (non-ephemeral) response parts
+            # The first part will edit the original deferred response. Subsequent parts will be new followups.
             for i, chunk_content_part in enumerate(raw_tweet_chunks):
                 chunk_title = embed_title if i == 0 else f"{embed_title} (cont.)"
-                await interaction.followup.send(embed=discord.Embed(
-                    title=chunk_title, 
-                    description=chunk_content_part, 
-                    color=config.EMBED_COLOR["incomplete"]
-                )) 
+                embed = discord.Embed(
+                    title=chunk_title,
+                    description=chunk_content_part,
+                    color=config.EMBED_COLOR["complete"] # Changed to complete for final results
+                )
+                if i == 0:
+                    await interaction.edit_original_response(embed=embed)
+                else:
+                    await interaction.followup.send(embed=embed)
+
 
             user_query_content_for_summary = (
                 f"Please analyze and summarize the main themes, topics discussed, and overall sentiment "
                 f"from @{clean_username}'s recent tweets provided below. Extract key points and present a concise overview. "
-                f"Do not just re-list the tweets.\n\nRecent Tweets:\n{raw_tweets_display_str[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}" 
+                f"Do not just re-list the tweets.\n\nRecent Tweets:\n{raw_tweets_display_str[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}"
             )
             user_msg_node = MsgNode("user", user_query_content_for_summary, name=str(interaction.user.id))
-            
+
             rag_query_for_tweets_summary = f"summary of recent tweets from Twitter user @{clean_username}"
             synthesized_rag_context = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_for_tweets_summary)
 
             prompt_nodes_summary = await _build_initial_prompt_messages(
-                user_query_content=user_query_content_for_summary, 
-                channel_id=interaction.channel_id, 
+                user_query_content=user_query_content_for_summary,
+                channel_id=interaction.channel_id,
                 bot_state=bot_state_instance,
                 user_id=str(interaction.user.id),
                 synthesized_rag_context_str=synthesized_rag_context
             )
             await stream_llm_response_to_interaction(
-                interaction, llm_client_instance, bot_state_instance, user_msg_node, prompt_nodes_summary, 
+                interaction, llm_client_instance, bot_state_instance, user_msg_node, prompt_nodes_summary,
                 title=f"Tweet Summary for @{clean_username}",
-                force_new_followup_flow=True, 
+                force_new_followup_flow=True,
                 synthesized_rag_context_for_display=synthesized_rag_context,
-                bot_user_id=bot_instance.user.id 
+                bot_user_id=bot_instance.user.id
             )
         except Exception as e:
             logger.error(f"Error in gettweets_slash_command for @{username}: {e}", exc_info=True)
-            await interaction.followup.send(f"My tweet-fetching antenna is bent! Failed for @{username}. Error: {str(e)[:1000]}", ephemeral=True)
+            # Ensure a progress message indicates failure if it reaches here
+            await send_progress(f"An error occurred while processing tweets for @{username}. Check logs.")
+            # Try to send a final message to the user if the interaction hasn't been fully responded to
+            final_error_message = f"My tweet-fetching antenna is bent! Failed for @{username}. Error: {str(e)[:500]}"
+            try:
+                if not interaction.response.is_done():
+                    await interaction.response.send_message(final_error_message, ephemeral=True)
+                else:
+                    await interaction.followup.send(final_error_message, ephemeral=True)
+            except discord.HTTPException: # Handle cases where even followup might fail (e.g. interaction expired)
+                 logger.warning(f"Could not send final error message for gettweets @{username} to user.")
+
 
     @bot_instance.tree.command(name="ap", description="Describes an attached image with a creative AP Photo twist.")
     @app_commands.describe(image="The image to describe.", user_prompt="Optional additional prompt for the description.")
@@ -544,7 +592,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
         if interaction.channel_id is None:
             await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
             return
-        
+
         await interaction.response.defer(ephemeral=False)
 
         try:
@@ -557,12 +605,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 logger.warning(f"Image {image.filename} provided by {interaction.user.name} is too large ({len(image_bytes)} bytes). Max allowed: {config.MAX_IMAGE_BYTES_FOR_PROMPT}.")
                 await interaction.followup.send(f"The image you attached is too large (max {config.MAX_IMAGE_BYTES_FOR_PROMPT // (1024*1024)}MB). Please try a smaller one.", ephemeral=True)
                 return
-            
+
             base64_image = base64.b64encode(image_bytes).decode('utf-8')
             image_url_for_llm = f"data:{image.content_type};base64,{base64_image}"
-            
-            chosen_celebrity = random.choice(["Keanu Reeves", "Dwayne 'The Rock' Johnson", "Zendaya", "Tom Hanks", "Margot Robbie", "Ryan Reynolds", "Morgan Freeman", "Awkwafina"]) 
-            
+
+            chosen_celebrity = random.choice(["Keanu Reeves", "Dwayne 'The Rock' Johnson", "Zendaya", "Tom Hanks", "Margot Robbie", "Ryan Reynolds", "Morgan Freeman", "Awkwafina"])
+
             ap_task_prompt_text = (
                 f"You are an Associated Press (AP) photo caption writer with a quirky sense of humor. Your task is to describe the attached image in vivid detail, as if for someone who cannot see it. "
                 f"However, here's the twist: you must creatively and seamlessly replace the main subject or a prominent character in the image with the celebrity **{chosen_celebrity}**. "
@@ -570,43 +618,43 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 f"Start your response with 'AP Photo: {chosen_celebrity}...' "
                 f"If the user provided an additional prompt, try to incorporate its theme or request into your {chosen_celebrity}-centric description: '{user_prompt if user_prompt else 'No additional user prompt.'}'"
             )
-            
+
             user_content_for_ap_node = [
                 {"type": "text", "text": user_prompt if user_prompt else "Describe this image with the AP Photo celebrity twist."},
                 {"type": "image_url", "image_url": {"url": image_url_for_llm}}
             ]
             user_msg_node = MsgNode("user", user_content_for_ap_node, name=str(interaction.user.id))
-            
+
             rag_query_for_ap = user_prompt if user_prompt else f"AP photo style description featuring {chosen_celebrity} for an image."
             synthesized_rag_context = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_for_ap)
 
             base_prompt_nodes = await _build_initial_prompt_messages(
-                user_query_content=user_content_for_ap_node, 
-                channel_id=interaction.channel_id, 
+                user_query_content=user_content_for_ap_node,
+                channel_id=interaction.channel_id,
                 bot_state=bot_state_instance,
                 user_id=str(interaction.user.id),
                 synthesized_rag_context_str=synthesized_rag_context,
-                max_image_history_depth=0 
+                max_image_history_depth=0
             )
-            
+
             insert_idx = 0
             for idx, node in enumerate(base_prompt_nodes):
                 if node.role != "system": insert_idx = idx; break
-                insert_idx = idx + 1 
+                insert_idx = idx + 1
             final_prompt_nodes = base_prompt_nodes[:insert_idx] + [MsgNode("system", ap_task_prompt_text)] + base_prompt_nodes[insert_idx:]
-            
+
             await stream_llm_response_to_interaction(
-                interaction, llm_client_instance, bot_state_instance, user_msg_node, final_prompt_nodes, 
-                title=f"AP Photo Description ft. {chosen_celebrity}", 
+                interaction, llm_client_instance, bot_state_instance, user_msg_node, final_prompt_nodes,
+                title=f"AP Photo Description ft. {chosen_celebrity}",
                 synthesized_rag_context_for_display=synthesized_rag_context,
-                bot_user_id=bot_instance.user.id 
+                bot_user_id=bot_instance.user.id
             )
         except Exception as e:
             logger.error(f"Error in ap_slash_command for image '{image.filename}': {e}", exc_info=True)
             await interaction.followup.send(f"My camera lens for the AP command seems to be cracked! Error: {str(e)[:1000]}", ephemeral=True)
 
     @bot_instance.tree.command(name="clearhistory", description="Clears the bot's short-term message history for this channel.")
-    @app_commands.checks.has_permissions(manage_messages=True) 
+    @app_commands.checks.has_permissions(manage_messages=True)
     async def clearhistory_slash_command(interaction: discord.Interaction):
         if not bot_state_instance:
              logger.error("clearhistory_slash_command: bot_state_instance is None.")
@@ -614,10 +662,10 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
              return
 
         if interaction.channel_id:
-            await bot_state_instance.clear_channel_history(interaction.channel_id) 
+            await bot_state_instance.clear_channel_history(interaction.channel_id)
             logger.info(f"Short-term message history cleared for channel {interaction.channel_id} by {interaction.user.name} ({interaction.user.id}).")
             await interaction.response.send_message("My short-term memory for this channel has been wiped clean!", ephemeral=True)
-        else: 
+        else:
             await interaction.response.send_message("Error: Could not determine the channel to clear history for.", ephemeral=True)
 
     @clearhistory_slash_command.error
@@ -630,4 +678,3 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                  await interaction.response.send_message(f"An unexpected error occurred: {str(error)[:500]}", ephemeral=True)
             else:
                  await interaction.followup.send(f"An unexpected error occurred: {str(error)[:500]}", ephemeral=True)
-

--- a/discord_events.py
+++ b/discord_events.py
@@ -1,36 +1,35 @@
 import logging
 import discord # type: ignore
-from discord import app_commands # Added this import
+from discord import app_commands
 from discord.ext import commands, tasks # type: ignore
-import base64 
-import asyncio 
-import os 
-from datetime import datetime 
-from typing import Any, Optional, List, Union, Dict 
+import base64
+import asyncio
+import os
+from datetime import datetime, timedelta # Added timedelta
+from typing import Any, Optional, List, Union, Dict
 
 # Bot services and utilities
 from config import config
 from state import BotState
-from common_models import MsgNode # Import MsgNode
+from common_models import MsgNode
 
 from llm_handling import (
-    _build_initial_prompt_messages, 
+    _build_initial_prompt_messages,
     stream_llm_response_to_message
 )
 from rag_chroma_manager import (
     retrieve_and_prepare_rag_context
 )
-# Corrected import for detect_urls
 from utils import detect_urls, cleanup_playwright_processes
-from web_utils import scrape_website, fetch_youtube_transcript 
-from audio_utils import transcribe_audio_file, send_tts_audio, load_whisper_model 
+from web_utils import scrape_website, fetch_youtube_transcript
+from audio_utils import transcribe_audio_file, send_tts_audio, load_whisper_model
 
 logger = logging.getLogger(__name__)
 
 # Module-level globals to store instances passed from main_bot.py
 bot_instance: Optional[commands.Bot] = None
 llm_client_instance: Optional[Any] = None
-bot_state_instance: Optional[BotState] = None
+bot_state_instance: Optional[BotState] = None # This will hold last_playwright_usage_time
 
 
 def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState):
@@ -39,37 +38,31 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
     llm_client_instance = llm_client_in
     bot_state_instance = bot_state_in
 
-    # Ensure instances are set before defining events/tasks that use them
     if not bot_instance or not llm_client_instance or not bot_state_instance:
         logger.critical("Bot, LLM client, or BotState not properly initialized in setup_events_and_tasks. Events/tasks may fail.")
-        return # Prevent events/tasks from being registered if setup is faulty
-
+        return
 
     @tasks.loop(seconds=30)
     async def check_reminders_task():
-        if not bot_state_instance or not bot_instance: # Check instances
+        if not bot_state_instance or not bot_instance:
             logger.error("check_reminders_task: Bot state or bot instance not available.")
             return
-
         now = datetime.now()
-        due_reminders_list = await bot_state_instance.pop_due_reminders(now) 
-        
+        due_reminders_list = await bot_state_instance.pop_due_reminders(now)
         for reminder_time, channel_id, user_id, message_content, original_time_str in due_reminders_list:
             logger.info(f"Reminder DUE for user {user_id} in channel {channel_id} at {reminder_time.strftime('%Y-%m-%d %H:%M:%S')}: {message_content}")
             try:
                 channel = await bot_instance.fetch_channel(channel_id)
-                user = await bot_instance.fetch_user(user_id) 
-                
-                if channel and user and isinstance(channel, discord.abc.Messageable): 
+                user = await bot_instance.fetch_user(user_id)
+                if channel and user and isinstance(channel, discord.abc.Messageable):
                     embed = discord.Embed(
-                        title=f"⏰ Reminder! (Originally set for ~{original_time_str})", 
-                        description=message_content, 
+                        title=f"⏰ Reminder! (Originally set for ~{original_time_str})",
+                        description=message_content,
                         color=discord.Color.blue(),
-                        timestamp=reminder_time 
+                        timestamp=reminder_time
                     )
                     embed.set_footer(text=f"This reminder was for {user.display_name}")
-                    await channel.send(content=user.mention, embed=embed) 
-                    
+                    await channel.send(content=user.mention, embed=embed)
                     tts_reminder_text = f"Hey {user.display_name}, here's your reminder: {message_content}"
                     await send_tts_audio(channel, tts_reminder_text, base_filename=f"reminder_{user_id}_{channel_id}")
                 else:
@@ -79,21 +72,43 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
             except Exception as e:
                 logger.error(f"Failed to send reminder (Channel ID {channel_id}, User ID {user_id}): {e}", exc_info=True)
 
-    @tasks.loop(minutes=10)
+    @tasks.loop(minutes=config.PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES if hasattr(config, 'PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES') else 5) # Default to 5 min if not in config
     async def cleanup_playwright_task():
+        if not bot_state_instance:
+            logger.error("cleanup_playwright_task: BotState not available.")
+            return
+
+        last_usage = await bot_state_instance.get_last_playwright_usage_time()
+        cleanup_threshold_minutes = config.PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES if hasattr(config, 'PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES') else 10 # Default to 10 min
+
+        if last_usage:
+            idle_time = datetime.now() - last_usage
+            if idle_time < timedelta(minutes=cleanup_threshold_minutes):
+                logger.debug(f"Playwright cleanup skipped. Last used {idle_time.total_seconds()//60:.0f}m ago (threshold: {cleanup_threshold_minutes}m).")
+                return
+            logger.info(f"Playwright idle for {idle_time.total_seconds()//60:.0f}m. Proceeding with cleanup check (threshold: {cleanup_threshold_minutes}m).")
+        else:
+            # If last_usage is None, it means either it was never used or cleaned up previously.
+            # We can proceed to clean up any potential orphaned processes.
+            logger.info("No recorded Playwright usage or previously cleaned. Proceeding with cleanup check.")
+
         killed = cleanup_playwright_processes()
         if killed:
-            logger.info(f"Cleaned up {killed} stray Chromium processes.")
+            logger.info(f"Cleaned up {killed} stray Chromium/Playwright processes.")
+            # After a successful cleanup, update the time, signifying active management.
+            await bot_state_instance.update_last_playwright_usage_time()
+        else:
+            logger.debug("Playwright cleanup task ran: No stray processes found or killed.")
+
 
     @bot_instance.event # type: ignore
     async def on_ready():
-        if not bot_instance or not bot_instance.user: 
+        if not bot_instance or not bot_instance.user:
             logger.critical("Bot user not available on_ready. This is highly unusual.")
             return
-
-        load_whisper_model() 
-
+        load_whisper_model()
         logger.info(f'{bot_instance.user.name} (ID: {bot_instance.user.id}) has connected to Discord!')
+        # ... (rest of on_ready remains the same)
         logger.info(f"discord.py version: {discord.__version__}")
         logger.info(f"Operating with LLM: {config.LLM_MODEL}, Vision: {config.VISION_LLM_MODEL}, FastLLM: {config.FAST_LLM_MODEL}")
         logger.info(f"Allowed Channel IDs: {config.ALLOWED_CHANNEL_IDS if config.ALLOWED_CHANNEL_IDS else 'All channels'}")
@@ -101,7 +116,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         logger.info(f"User-Provided Global Context is {'SET' if config.USER_PROVIDED_CONTEXT else 'NOT SET'}.")
         logger.info(f"Max Image Bytes: {config.MAX_IMAGE_BYTES_FOR_PROMPT}, Max Scraped Text: {config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT}")
         logger.info(f"Stream Edit Throttle: {config.STREAM_EDIT_THROTTLE_SECONDS}s, RAG Sentences to Fetch: {config.RAG_NUM_DISTILLED_SENTENCES_TO_FETCH}")
-        
+
         try:
             synced = await bot_instance.tree.sync()
             logger.info(f"Synced {len(synced)} slash commands to Discord.")
@@ -119,35 +134,36 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         await bot_instance.change_presence(activity=discord.Game(name="with /commands | Ask me anything!"))
         logger.info("Bot presence updated.")
 
+
     @bot_instance.event # type: ignore
     async def on_message(message: discord.Message):
         if not bot_instance or not bot_instance.user or not llm_client_instance or not bot_state_instance:
             logger.error("on_message: Bot components (bot, llm_client, bot_state) not ready. Skipping message processing.")
             return
 
-        if message.author.bot: return 
-        if message.channel is None or message.channel.id is None : 
+        if message.author.bot: return
+        if message.channel is None or message.channel.id is None :
             logger.warning(f"Message from {message.author.name} arrived without a channel or channel ID. Ignoring."); return
 
-        prefixes = await bot_instance.get_prefix(message) 
+        prefixes = await bot_instance.get_prefix(message)
         is_command_attempt = False
         if isinstance(prefixes, (list, tuple)):
             is_command_attempt = any(message.content.startswith(p) for p in prefixes)
         elif isinstance(prefixes, str):
             is_command_attempt = message.content.startswith(prefixes)
-        
+
         if is_command_attempt:
-            await bot_instance.process_commands(message) 
-            return 
+            await bot_instance.process_commands(message)
+            return
 
         is_dm = isinstance(message.channel, discord.DMChannel)
         is_mentioned = bot_instance.user in message.mentions
-        
+
         channel_id = message.channel.id
-        author_roles = getattr(message.author, 'roles', []) 
-        
+        author_roles = getattr(message.author, 'roles', [])
+
         allowed_by_channel = False
-        if not config.ALLOWED_CHANNEL_IDS: 
+        if not config.ALLOWED_CHANNEL_IDS:
             allowed_by_channel = True
         elif channel_id in config.ALLOWED_CHANNEL_IDS:
             allowed_by_channel = True
@@ -155,59 +171,60 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
             allowed_by_channel = True
 
         allowed_by_role = False
-        if not config.ALLOWED_ROLE_IDS or is_dm: 
+        if not config.ALLOWED_ROLE_IDS or is_dm:
             allowed_by_role = True
         else:
             allowed_by_role = any(role.id in config.ALLOWED_ROLE_IDS for role in author_roles)
-        
+
         should_respond = is_dm or is_mentioned or (allowed_by_channel and allowed_by_role)
-        
+
         if not should_respond:
-            if not (is_dm or is_mentioned): 
+            if not (is_dm or is_mentioned):
                 if not allowed_by_channel: logger.debug(f"Message from {message.author.name} in Channel ID {channel_id} ignored (channel not in ALLOWED_CHANNEL_IDS).")
                 elif not allowed_by_role: logger.debug(f"Message from {message.author.name} in Channel ID {channel_id} ignored (user role not in ALLOWED_ROLE_IDS).")
-            return 
+            return
 
         logger.info(f"General LLM processing for message from {message.author.name} in {getattr(message.channel, 'name', f'Channel ID {channel_id}')}: '{message.content[:50]}...'")
-        
-        current_message_content_parts: List[Dict[str, Any]] = [] 
+
+        current_message_content_parts: List[Dict[str, Any]] = []
         user_message_text_for_processing = message.content
         if f"<@{bot_instance.user.id}>" in user_message_text_for_processing:
             user_message_text_for_processing = user_message_text_for_processing.replace(f"<@{bot_instance.user.id}>", "").strip()
-        elif f"<@!{bot_instance.user.id}>" in user_message_text_for_processing: 
+        elif f"<@!{bot_instance.user.id}>" in user_message_text_for_processing:
              user_message_text_for_processing = user_message_text_for_processing.replace(f"<@!{bot_instance.user.id}>", "").strip()
-
 
         if message.attachments:
             for attachment in message.attachments:
                 if attachment.content_type and attachment.content_type.startswith("audio/"):
+                    # ... (audio processing remains the same)
                     try:
                         if not os.path.exists("temp"): os.makedirs("temp")
                         original_filename_parts = attachment.filename.split('.')
-                        safe_suffix = "dat" 
+                        safe_suffix = "dat"
                         if len(original_filename_parts) > 1:
                             raw_suffix = original_filename_parts[-1]
-                            safe_suffix = "".join(c if c.isalnum() else "_" for c in raw_suffix)[:10] 
-                        
+                            safe_suffix = "".join(c if c.isalnum() else "_" for c in raw_suffix)[:10]
+
                         audio_filename = f"temp/temp_audio_{attachment.id}.{safe_suffix}"
                         await attachment.save(audio_filename)
-                        transcription = transcribe_audio_file(audio_filename) 
-                        if os.path.exists(audio_filename): os.remove(audio_filename) 
-                        
-                        if transcription: 
+                        transcription = transcribe_audio_file(audio_filename)
+                        if os.path.exists(audio_filename): os.remove(audio_filename)
+
+                        if transcription:
                             capped_transcription = transcription[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]
                             user_message_text_for_processing = (f"[Audio Transcript from {attachment.filename}: {capped_transcription}] " + user_message_text_for_processing).strip()
                             logger.info(f"Added audio transcript (capped at {config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT} chars): {capped_transcription[:50]}...")
                     except Exception as e:
                         logger.error(f"Error processing audio attachment '{attachment.filename}': {e}", exc_info=True)
-                    break 
+                    break
 
         current_message_content_parts.append({"type": "text", "text": user_message_text_for_processing if user_message_text_for_processing else ""})
 
         image_added_to_prompt = False; images_processed_count = 0
         if message.attachments:
             for attachment in message.attachments:
-                if images_processed_count >= config.MAX_IMAGES_PER_MESSAGE: break 
+                # ... (image processing remains the same)
+                if images_processed_count >= config.MAX_IMAGES_PER_MESSAGE: break
                 if attachment.content_type and attachment.content_type.startswith("image/"):
                     try:
                         img_bytes = await attachment.read()
@@ -217,7 +234,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                                 if part["type"] == "text":
                                     part["text"] += f" [Note: Attached image '{attachment.filename}' was too large to process.]"
                                     break
-                            continue 
+                            continue
 
                         b64_img = base64.b64encode(img_bytes).decode('utf-8')
                         current_message_content_parts.append({"type": "image_url", "image_url": {"url": f"data:{attachment.content_type};base64,{b64_img}"}})
@@ -225,59 +242,69 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                         logger.info(f"Added image '{attachment.filename}' to prompt for message from {message.author.name}.")
                     except Exception as e:
                         logger.error(f"Error processing image attachment '{attachment.filename}': {e}", exc_info=True)
-        
+
         text_part_exists_with_content = any(p["type"] == "text" and p.get("text","").strip() for p in current_message_content_parts)
         if image_added_to_prompt and not text_part_exists_with_content:
+             # ... (image text part handling remains the same)
             text_part_updated = False
             for part in current_message_content_parts:
                 if part["type"] == "text":
                     part["text"] = "User sent image(s). Please describe or respond based on the image(s)."
                     text_part_updated = True
                     break
-            if not text_part_updated: 
+            if not text_part_updated:
                  current_message_content_parts.insert(0, {"type": "text", "text": "User sent image(s). Please describe or respond based on the image(s)."})
 
 
         current_text_for_url_detection = ""
         for part in current_message_content_parts:
             if part["type"] == "text":
-                current_text_for_url_detection = part["text"]; # type: ignore
-                break 
-            
-        scraped_content_accumulator = [] 
-        if detected_urls_in_text := detect_urls(str(current_text_for_url_detection)): 
-            for i, url in enumerate(detected_urls_in_text[:2]): 
+                current_text_for_url_detection = part["text"];
+                break
+
+        scraped_content_accumulator = []
+        if detected_urls_in_text := detect_urls(str(current_text_for_url_detection)):
+            playwright_used_in_loop = False # Track if Playwright was used in this loop
+            for i, url in enumerate(detected_urls_in_text[:2]):
                 logger.info(f"Processing URL from message (index {i}): {url}")
                 content_piece = None
-                
-                is_googleusercontent_youtube = "googleusercontent.com/youtube.com/" in url 
-                youtube_indicators = ["youtube.com/watch", "youtu.be/", "youtube.com/shorts", "googleusercontent.com/youtube.com/"] # Removed /3, /1, /6
+
+                is_googleusercontent_youtube = "googleusercontent.com/youtube.com/" in url
+                youtube_indicators = ["youtube.com/watch", "youtu.be/", "youtube.com/shorts", "googleusercontent.com/youtube.com/"]
                 is_any_youtube_type = any(indicator in url for indicator in youtube_indicators) or "youtube.com/watch?v=" in url or "youtu.be/" in url
 
-
-                if is_any_youtube_type: 
-                    transcript = await fetch_youtube_transcript(url) 
+                if is_any_youtube_type:
+                    # fetch_youtube_transcript might call scrape_website (Playwright) as a fallback
+                    if bot_state_instance: await bot_state_instance.update_last_playwright_usage_time()
+                    playwright_used_in_loop = True
+                    transcript = await fetch_youtube_transcript(url)
                     if transcript:
                         content_piece = f"\n\n--- YouTube Transcript for {url} ---\n{transcript}\n--- End Transcript ---"
                         logger.info(f"Successfully fetched YouTube transcript for {url}.")
-                    elif not is_googleusercontent_youtube: # Only fallback if not the specific "0" type
+                    elif not is_googleusercontent_youtube:
                         logger.warning(f"YouTube transcript failed for {url}. Falling back to generic web scrape of the page.")
-                        scraped_text = await scrape_website(url) 
+                        # scrape_website uses Playwright
+                        if bot_state_instance: await bot_state_instance.update_last_playwright_usage_time() # Ensure it's updated again if called directly
+                        playwright_used_in_loop = True
+                        scraped_text = await scrape_website(url)
                         if scraped_text and "Failed to scrape" not in scraped_text and "Scraping timed out" not in scraped_text:
                             content_piece = f"\n\n--- Webpage Content (fallback for YouTube URL {url}) ---\n{scraped_text}\n--- End Webpage Content ---"
                             logger.info(f"Fetched webpage content for {url} (YouTube transcript fallback).")
                         else:
                             logger.warning(f"Failed to get transcript or scrape fallback for YouTube URL {url}. Scraped_text: '{scraped_text}'")
-                    else: 
+                    else:
                          logger.warning(f"Failed to get YouTube transcript for {url} (specific googleusercontent type '0'). Skipping generic web scrape for this pattern.")
-                else: 
+                else:
+                    # scrape_website uses Playwright
+                    if bot_state_instance: await bot_state_instance.update_last_playwright_usage_time()
+                    playwright_used_in_loop = True
                     scraped_text = await scrape_website(url)
                     if scraped_text and "Failed to scrape" not in scraped_text and "Scraping timed out" not in scraped_text:
                         content_piece = f"\n\n--- Webpage Content for {url} ---\n{scraped_text}\n--- End Webpage Content ---"
                         logger.info(f"Fetched webpage content for non-YouTube URL: {url}.")
                     else:
                         logger.warning(f"Failed to scrape content for non-YouTube URL {url}. Scraped_text: '{scraped_text}'")
-                
+
                 if content_piece:
                     scraped_content_accumulator.append(content_piece)
                 else:
@@ -285,23 +312,28 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                     scraped_content_accumulator.append(notice)
                     logger.info(f"Appended notice for failed content retrieval: {url}")
                 await asyncio.sleep(0.2)
-        
-        final_user_message_text_for_llm = user_message_text_for_processing 
+
+            if playwright_used_in_loop and bot_state_instance: # Log overall usage if any specific call happened
+                 logger.debug("Playwright usage time updated due to URL processing in on_message.")
+
+
+        final_user_message_text_for_llm = user_message_text_for_processing
+        # ... (rest of message processing and LLM call remains the same)
         if scraped_content_accumulator:
             combined_scraped_content = "".join(scraped_content_accumulator)
-            max_total_scraped_len = config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT * 1.5 
-            if len(combined_scraped_content) > max_total_scraped_len: 
+            max_total_scraped_len = config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT * 1.5
+            if len(combined_scraped_content) > max_total_scraped_len:
                 combined_scraped_content = combined_scraped_content[:int(max_total_scraped_len)] + "\n[Combined scraped content truncated due to length]..."
-            
+
             final_user_message_text_for_llm = combined_scraped_content + "\n\nUser's message (following processed URL content and/or audio transcript, if any): " + user_message_text_for_processing
-        
+
         text_part_found_and_updated_with_scrape = False
         for part_idx, part_dict in enumerate(current_message_content_parts):
             if part_dict["type"] == "text":
                 current_message_content_parts[part_idx]["text"] = final_user_message_text_for_llm
                 text_part_found_and_updated_with_scrape = True
                 break
-        if not text_part_found_and_updated_with_scrape: 
+        if not text_part_found_and_updated_with_scrape:
             logger.error("Critical: Text part missing in current_message_content_parts before LLM call.")
             current_message_content_parts.insert(0, {"type": "text", "text": final_user_message_text_for_llm})
 
@@ -314,10 +346,10 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                 has_text_content = True
             if part.get("type") == "image_url":
                 has_image_content = True
-        
+
         if has_text_content or has_image_content:
             final_content_is_empty = False
-            
+
         if final_content_is_empty:
             logger.info(f"Ignoring message from {message.author.name} as it resulted in no processable content after all stages."); return
 
@@ -325,43 +357,44 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         if len(current_message_content_parts) == 1 and current_message_content_parts[0]["type"] == "text" and not has_image_content:
             user_msg_node_content_final = current_message_content_parts[0]["text"]
         else:
-            user_msg_node_content_final = current_message_content_parts # type: ignore
-        
+            user_msg_node_content_final = current_message_content_parts
+
         rag_query_text = user_message_text_for_processing.strip() if user_message_text_for_processing.strip() else \
                          ("User sent an image/attachment" if image_added_to_prompt else "User sent a message with no textual content.")
         synthesized_rag_context = await retrieve_and_prepare_rag_context(llm_client_instance, rag_query_text)
-        
+
         user_msg_node_for_short_term_history = MsgNode("user", user_msg_node_content_final, name=str(message.author.id))
 
         llm_prompt_for_current_turn = await _build_initial_prompt_messages(
-            user_query_content=user_msg_node_content_final, 
+            user_query_content=user_msg_node_content_final,
             channel_id=channel_id,
-            bot_state=bot_state_instance, 
+            bot_state=bot_state_instance,
             user_id=str(message.author.id),
-            synthesized_rag_context_str=synthesized_rag_context 
+            synthesized_rag_context_str=synthesized_rag_context
         )
-        
+
         await stream_llm_response_to_message(
-            target_message=message, 
-            llm_client=llm_client_instance, 
-            bot_state=bot_state_instance,   
-            user_msg_node=user_msg_node_for_short_term_history, 
+            target_message=message,
+            llm_client=llm_client_instance,
+            bot_state=bot_state_instance,
+            user_msg_node=user_msg_node_for_short_term_history,
             prompt_messages=llm_prompt_for_current_turn,
             synthesized_rag_context_for_display=synthesized_rag_context,
-            bot_user_id=bot_instance.user.id 
+            bot_user_id=bot_instance.user.id
         )
 
-    @bot_instance.event # type: ignore
+    # ... (on_raw_reaction_add, on_app_command_error, on_command_error remain the same)
+    @bot_instance.event
     async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
-        if not bot_instance or not bot_instance.user : return 
+        if not bot_instance or not bot_instance.user : return
 
-        if payload.user_id == bot_instance.user.id or str(payload.emoji) != '❌': 
-            return 
-        if payload.channel_id is None: 
+        if payload.user_id == bot_instance.user.id or str(payload.emoji) != '❌':
+            return
+        if payload.channel_id is None:
             return
 
         channel: Optional[discord.abc.Messageable] = None
-        message_obj: Optional[discord.Message] = None 
+        message_obj: Optional[discord.Message] = None
 
         try:
             fetched_channel = await bot_instance.fetch_channel(payload.channel_id)
@@ -370,122 +403,121 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                 return
             channel = fetched_channel
             message_obj = await channel.fetch_message(payload.message_id)
-        except (discord.NotFound, discord.Forbidden): 
+        except (discord.NotFound, discord.Forbidden):
             logger.warning(f"Could not fetch message {payload.message_id} in channel {payload.channel_id} for ❌ reaction.")
-            return 
-        
-        if message_obj is None or message_obj.author.id != bot_instance.user.id: 
-            return 
+            return
 
-        can_delete = False 
+        if message_obj is None or message_obj.author.id != bot_instance.user.id:
+            return
+
+        can_delete = False
         user_who_reacted = None
         if isinstance(channel, (discord.TextChannel, discord.Thread)) and channel.guild:
             try:
-                member = await channel.guild.fetch_member(payload.user_id) 
-                user_who_reacted = member 
-                if member and member.guild_permissions.manage_messages: 
+                member = await channel.guild.fetch_member(payload.user_id)
+                user_who_reacted = member
+                if member and member.guild_permissions.manage_messages:
                     can_delete = True
-            except discord.HTTPException: 
+            except discord.HTTPException:
                 logger.debug(f"Could not fetch member {payload.user_id} in guild {channel.guild.id}.")
-                pass 
-        elif isinstance(channel, discord.DMChannel): 
-            can_delete = True 
+                pass
+        elif isinstance(channel, discord.DMChannel):
+            can_delete = True
             try: user_who_reacted = await bot_instance.fetch_user(payload.user_id)
             except discord.NotFound: pass
 
 
         if not can_delete:
-            if message_obj.interaction and message_obj.interaction.user.id == payload.user_id: 
+            if message_obj.interaction and message_obj.interaction.user.id == payload.user_id:
                 can_delete = True
-            elif message_obj.reference and message_obj.reference.message_id and channel: 
-                try: 
+            elif message_obj.reference and message_obj.reference.message_id and channel:
+                try:
                     original_message = await channel.fetch_message(message_obj.reference.message_id)
-                    if original_message.author.id == payload.user_id: 
+                    if original_message.author.id == payload.user_id:
                         can_delete = True
-                except discord.NotFound: 
-                    pass 
+                except discord.NotFound:
+                    pass
 
         if can_delete:
-            try: 
+            try:
                 await message_obj.delete()
                 reactor_name = user_who_reacted.name if user_who_reacted else f"User ID {payload.user_id}"
                 logger.info(f"Message {message_obj.id} (sent by bot) deleted by ❌ reaction from {reactor_name}.")
             except discord.Forbidden:
                 logger.warning(f"Bot lacked permissions to delete message {message_obj.id} despite can_delete logic.")
-            except discord.HTTPException as e: 
+            except discord.HTTPException as e:
                 logger.error(f"Failed to delete message {message_obj.id} by reaction: {e}")
         else:
             logger.debug(f"User {payload.user_id} reacted with ❌ on message {message_obj.id}, but lacked deletion rights.")
 
-    @bot_instance.event # type: ignore
-    async def on_app_command_error(interaction: discord.Interaction, error: app_commands.AppCommandError): 
+    @bot_instance.event
+    async def on_app_command_error(interaction: discord.Interaction, error: app_commands.AppCommandError):
         command_name = interaction.command.name if interaction.command else 'unknown_slash_command'
-        logger.error(f"Error in slash command '{command_name}' invoked by {interaction.user.name} ({interaction.user.id}): {error}", exc_info=True) 
-        
+        logger.error(f"Error in slash command '{command_name}' invoked by {interaction.user.name} ({interaction.user.id}): {error}", exc_info=True)
+
         error_message = "An unexpected error occurred while trying to run this slash command."
         original_error_is_unknown_interaction = False
 
-        if isinstance(error, app_commands.CommandInvokeError): 
+        if isinstance(error, app_commands.CommandInvokeError):
             original_error = error.original
-            if isinstance(original_error, discord.errors.NotFound) and original_error.code == 10062: 
+            if isinstance(original_error, discord.errors.NotFound) and original_error.code == 10062:
                 error_message = "The command took too long to respond initially, or the interaction may have expired. Please try the command again."
                 logger.warning(f"Acknowledged 'Unknown Interaction' (Discord API error 10062) for command '{command_name}'. Interaction ID: {interaction.id}. User notified to retry.")
-                original_error_is_unknown_interaction = True 
-            else: 
+                original_error_is_unknown_interaction = True
+            else:
                 error_message = f"The command '{command_name}' encountered an issue: {str(original_error)[:500]}"
-        elif isinstance(error, app_commands.CommandNotFound): 
+        elif isinstance(error, app_commands.CommandNotFound):
             error_message = "That slash command was not found. This is unexpected if you used the UI."
-        elif isinstance(error, app_commands.MissingPermissions): 
+        elif isinstance(error, app_commands.MissingPermissions):
             error_message = f"You don't have the required permissions to use this command: {', '.join(error.missing_permissions)}"
-        elif isinstance(error, app_commands.BotMissingPermissions): 
+        elif isinstance(error, app_commands.BotMissingPermissions):
             error_message = f"I don't have the required permissions to perform this action: {', '.join(error.missing_permissions)}"
-        elif isinstance(error, app_commands.CheckFailure): 
+        elif isinstance(error, app_commands.CheckFailure):
             error_message = "You do not meet the requirements to use this command."
-        elif isinstance(error, app_commands.CommandOnCooldown): 
+        elif isinstance(error, app_commands.CommandOnCooldown):
             error_message = f"This command is on cooldown. Please try again in {error.retry_after:.2f} seconds."
-        elif isinstance(error, app_commands.TransformerError): 
+        elif isinstance(error, app_commands.TransformerError):
             param_name = error.param.name if hasattr(error, 'param') and error.param else 'unknown_parameter'
             expected_type_str = str(error.type) if hasattr(error, 'type') else 'unknown_type'
             error_message = f"There was an issue with one of the arguments you provided for '{command_name}'. Parameter: {param_name}, Value: '{error.value}'. Expected type: {expected_type_str}."
-        
-        if original_error_is_unknown_interaction: 
-            return 
+
+        if original_error_is_unknown_interaction:
+            return
 
         try:
-            if interaction.response.is_done(): 
+            if interaction.response.is_done():
                 await interaction.followup.send(error_message, ephemeral=True)
-            else: 
+            else:
                 await interaction.response.send_message(error_message, ephemeral=True)
-        except discord.errors.HTTPException as ehttp: 
-            if ehttp.code == 40060: 
+        except discord.errors.HTTPException as ehttp:
+            if ehttp.code == 40060:
                 logger.warning(f"Error handler: Interaction for '{command_name}' was already acknowledged. Attempting followup for error message. Original error: {error}")
-                try: 
-                    await interaction.followup.send(error_message, ephemeral=True) 
-                except Exception as e_followup: 
+                try:
+                    await interaction.followup.send(error_message, ephemeral=True)
+                except Exception as e_followup:
                     logger.error(f"Error handler: Failed to send followup error message for '{command_name}' after 40060: {e_followup}")
-            else: 
+            else:
                 logger.error(f"Error handler: An HTTPException occurred while trying to send error for '{command_name}': {ehttp}. Original error: {error}")
-        except discord.errors.NotFound: 
+        except discord.errors.NotFound:
             logger.error(f"Error handler: Interaction for '{command_name}' not found. It might have expired before error handling. Original error: {error}")
-        except Exception as e_generic: 
+        except Exception as e_generic:
             logger.error(f"Error handler: A generic error occurred while trying to send error for '{command_name}': {e_generic}. Original error: {error}")
 
-    @bot_instance.event # type: ignore
-    async def on_command_error(ctx: commands.Context, error: commands.CommandError): 
+    @bot_instance.event
+    async def on_command_error(ctx: commands.Context, error: commands.CommandError):
         command_name_str = ctx.command.name if ctx.command else "unknown_prefix_command"
         if isinstance(error, commands.CommandNotFound):
             logger.debug(f"Prefix command not found: {ctx.message.content.split()[0]} by {ctx.author.name}")
-            pass 
+            pass
         elif isinstance(error, commands.MissingRequiredArgument):
             param_name = error.param.name if hasattr(error, 'param') and error.param else 'unknown_argument'
             await ctx.reply(f"You're missing an argument for `!{command_name_str}`: `{param_name}`.", silent=True)
         elif isinstance(error, commands.BadArgument):
             await ctx.reply(f"That's not a valid argument for `!{command_name_str}`. Please check the expected type.", silent=True)
-        elif isinstance(error, commands.CheckFailure): 
+        elif isinstance(error, commands.CheckFailure):
             await ctx.reply("You don't have permission to use that prefix command.", silent=True)
         elif isinstance(error, commands.CommandInvokeError):
             logger.error(f"Error invoking prefix command `!{command_name_str}` by {ctx.author.name}: {error.original}", exc_info=error.original)
             await ctx.reply(f"Oops! Something went wrong with `!{command_name_str}`: {str(error.original)[:500]}", silent=True)
         else:
             logger.error(f"An unhandled error occurred with a prefix command (`{ctx.invoked_with}` by {ctx.author.name}): {error}", exc_info=True)
-

--- a/web_utils.py
+++ b/web_utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import json
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Callable, Awaitable
 from bs4 import BeautifulSoup
 import random
 import hashlib
@@ -140,7 +140,7 @@ async def _scrape_with_bs(url: str) -> Optional[str]:
         logger.warning(f"BeautifulSoup fallback failed for {url}: {e}")
     return None
 
-async def scrape_website(url: str) -> Optional[str]:
+async def scrape_website(url: str, progress_callback: Optional[Callable[[str], Awaitable[None]]] = None) -> Optional[str]: # Added progress_callback for consistency, though not used in this specific function in the plan
     logger.info(f"Attempting to scrape website: {url}")
     user_data_dir = os.path.join(os.getcwd(), ".pw-profile")
     profile_dir_usable = True
@@ -250,9 +250,13 @@ async def scrape_website(url: str) -> Optional[str]:
 
     except PlaywrightTimeoutError:
         logger.error(f"Playwright timed out during the scraping process for {url}")
+        if progress_callback: # Notify about timeout
+            await progress_callback(f"Scraping {url} timed out.")
         return "Scraping timed out."
     except Exception as e:
         logger.error(f"Playwright encountered an unexpected error for {url}: {e}", exc_info=True)
+        if progress_callback: # Notify about error
+            await progress_callback(f"Failed to scrape {url} due to an error.")
         return "Failed to scrape the website due to an unexpected error."
     finally:
         if page and not page.is_closed():
@@ -267,7 +271,7 @@ async def scrape_website(url: str) -> Optional[str]:
             try: await browser_instance_sw.close()
             except Exception: pass
 
-async def scrape_latest_tweets(username_queried: str, limit: int = 10) -> List[Dict[str, Any]]:
+async def scrape_latest_tweets(username_queried: str, limit: int = 10, progress_callback: Optional[Callable[[str], Awaitable[None]]] = None) -> List[Dict[str, Any]]:
     logger.info(f"Scraping last {limit} tweets for @{username_queried} (profile page, with replies) using Playwright JS execution.")
     tweets_collected: List[Dict[str, Any]] = []
     seen_tweet_ids: set[str] = set()
@@ -355,10 +359,17 @@ async def scrape_latest_tweets(username_queried: str, limit: int = 10) -> List[D
                             tweets_collected.append(data)
                             seen_tweet_ids.add(uid)
                             newly_added_count +=1
+                            if progress_callback:
+                                try:
+                                    await progress_callback(f"Scraped {len(tweets_collected)}/{limit} tweets for @{username_queried}...")
+                                except Exception as e_cb:
+                                    logger.warning(f"Progress callback error: {e_cb}")
                             if len(tweets_collected) >= limit: break
 
-                    if newly_added_count == 0 and scroll_attempt > (limit // 2 + 7):
+                    if newly_added_count == 0 and scroll_attempt > (limit // 2 + 7): # Increased patience slightly
                         logger.info("No new unique tweets found in several scroll attempts. Stopping.")
+                        if progress_callback:
+                            await progress_callback(f"Stopping early: No new unique tweets found after {scroll_attempt + 1} scrolls. Collected {len(tweets_collected)}.")
                         break
 
                     # Scroll down to load more tweets
@@ -371,8 +382,12 @@ async def scrape_latest_tweets(username_queried: str, limit: int = 10) -> List[D
 
     except PlaywrightTimeoutError as e:
         logger.warning(f"Playwright overall timeout during tweet scraping for @{username_queried}: {e}")
+        if progress_callback:
+            await progress_callback(f"Tweet scraping for @{username_queried} timed out overall. Collected {len(tweets_collected)}.")
     except Exception as e:
         logger.error(f"Unexpected error during tweet scraping for @{username_queried}: {e}", exc_info=True)
+        if progress_callback:
+            await progress_callback(f"An unexpected error occurred while scraping tweets for @{username_queried}. Collected {len(tweets_collected)}.")
     finally:
         if page and not page.is_closed():
             try: await page.close()


### PR DESCRIPTION
- Added progress callback to `scrape_latest_tweets` in `web_utils.py` to show scraping progress (e.g., "Scraped X/Y tweets").
- Updated `/gettweets` command in `discord_commands.py` to utilize this progress callback, sending ephemeral updates to the user.
- Modified Playwright cleanup logic in `discord_events.py`:
    - Cleanup task now checks `last_playwright_usage_time` (stored in `BotState`).
    - Cleanup only occurs if Playwright has been idle for a configurable threshold (default 10 minutes).
    - The cleanup task interval is also configurable (default 5 minutes).
    - `last_playwright_usage_time` is updated after a successful cleanup.
- Added `last_playwright_usage_time` attribute and associated methods to `BotState` in `state.py`.
- Ensured `last_playwright_usage_time` is updated in all commands using Playwright (`/gettweets`, `/news`, `/roast`) and in `on_message` when processing URLs that might trigger Playwright.
- Added new configuration options to `config.py`:
    - `PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES`
    - `PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES`