### PR TITLE
Refine entity extraction prompt to focus on recent messages

### DIFF
--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -105,6 +105,8 @@ async def extract_structured_data_llm(
 
     user_prompt_template = """\
 Please extract entities, relations, and observations from the following text.
+Pay close attention to the most recent interactions (user query and assistant response),
+typically found towards the end of the text, as they are of high importance for extraction.
 
 TEXT TO ANALYZE:
 ---


### PR DESCRIPTION
Modified the prompt in `extract_structured_data_llm` to explicitly instruct the LLM to pay closer attention to the most recent interactions (user query and assistant response) within the provided text. This aims to improve the relevance and accuracy of entity extraction from the latest parts of the conversation history.