### PR TITLE
Add RSS feed summarizer

### DIFF
--- a/rss_cache.py
+++ b/rss_cache.py
@@ -1,0 +1,27 @@
+import json
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+CACHE_FILE = os.path.join(os.path.dirname(__file__), "rss_seen.json")
+
+
+def load_seen_entries() -> dict:
+    if os.path.exists(CACHE_FILE):
+        try:
+            with open(CACHE_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    return data
+        except Exception as e:
+            logger.error(f"Failed to load RSS cache from {CACHE_FILE}: {e}")
+    return {}
+
+
+def save_seen_entries(data: dict) -> None:
+    try:
+        with open(CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+    except Exception as e:
+        logger.error(f"Failed to save RSS cache to {CACHE_FILE}: {e}")


### PR DESCRIPTION
## Summary
- introduce new rss cache module to track processed feed entries
- add `fetch_rss_entries` helper in `web_utils`
- create `/rss` command to fetch and summarize new articles from feeds

## Testing
- `python -m py_compile discord_commands.py web_utils.py rss_cache.py`

------
https://chatgpt.com/codex/tasks/task_e_68661da6ff6483289efcadd79c164c57