### PR TITLE
Add daily timeline pruning task

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Some of the most important settings you can tweak via the `.env` file are listed
 * `MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT` – limit for scraped text added to prompts.
 * `NEWS_MAX_LINKS_TO_PROCESS` – number of news links to read with `/gettweets`.
 * `SCRAPE_SCROLL_ATTEMPTS` – how many times to scroll when scraping a webpage to load dynamic content.
+* `TIMELINE_PRUNE_DAYS` – how many days of chat history to retain before daily pruning and summarization.
 
 ---
 


### PR DESCRIPTION
## Summary
- schedule timeline pruning to run every 24 hours
- start the timeline pruning task on bot ready
- document `TIMELINE_PRUNE_DAYS` env var

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665c2256448328873a6a6ca3b20f12