### PR TITLE
Sequential scraping lock and TTS gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ DiscordSam is a modular Python application designed for extensibility and mainta
         *   Scheduled reminders.
         *   Timestamp of the last Playwright usage (for automated cleanup).
         *   Per-channel locks to prevent concurrent LLM streaming operations within the same channel.
+        *   A global scrape lock ensures web scraping tasks (e.g., RSS fetching) run one at a time, queuing subsequent requests until the previous one's TTS is delivered.
     *   Instances of `BotState` are passed to modules that need to access or modify this shared information (e.g., command handlers, event processors).
 
 4.  **Discord Event Handlers (`discord_events.py`)**:

--- a/state.py
+++ b/state.py
@@ -15,6 +15,8 @@ class BotState:
         self.last_playwright_usage_time: Optional[datetime] = None
         # Locks to ensure only one LLM stream per channel at a time
         self.channel_locks = defaultdict(asyncio.Lock)
+        # Global lock to serialize scraping operations across commands
+        self.scrape_lock = asyncio.Lock()
 
     async def update_last_playwright_usage_time(self):
         """Updates the timestamp for the last Playwright usage."""
@@ -63,3 +65,7 @@ class BotState:
     def get_channel_lock(self, channel_id: int) -> asyncio.Lock:
         """Retrieve (or create) the asyncio.Lock for a specific channel."""
         return self.channel_locks[channel_id]
+
+    def get_scrape_lock(self) -> asyncio.Lock:
+        """Retrieve the global lock used for serializing scraping tasks."""
+        return self.scrape_lock


### PR DESCRIPTION
## Summary
- add `scrape_lock` to `BotState` and expose `get_scrape_lock`
- wait for TTS inside response streaming to keep message order
- serialize RSS command execution with the scrape lock and wait for TTS
- document new scrape lock in README

## Testing
- `python -m py_compile state.py llm_handling.py discord_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_6867582627ec83288b285ef93034fa91