### PR TITLE
Fix: Prevent concurrent get_tweets execution using scrape_lock

### DIFF
--- a/config.py
+++ b/config.py
@@ -133,6 +133,8 @@ class Config:
         self.PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES = _get_int("PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES", 5) # How often the cleanup task runs
         self.PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES = _get_int("PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES", 10) # How long Playwright must be idle before cleanup
 
+        self.SCRAPE_LOCK_TIMEOUT_SECONDS = _get_int("SCRAPE_LOCK_TIMEOUT_SECONDS", 60) # Timeout for acquiring scrape lock
+
 
 # Global config instance
 config = Config()


### PR DESCRIPTION
Implemented a lock mechanism for the /gettweets command to prevent multiple instances from running concurrently.

- Modified `gettweets_slash_command` in `discord_commands.py` to acquire and release a shared `scrape_lock` from `BotState`.
- Added a timeout (`config.SCRAPE_LOCK_TIMEOUT_SECONDS`) for acquiring the lock to prevent indefinite waiting and provide user feedback.
- Added `SCRAPE_LOCK_TIMEOUT_SECONDS` to `config.py` with a default value of 60 seconds.
- Ensured progress messages are sent to the user while waiting for the lock and during scraping.
- Improved error handling to release the lock reliably.