### PR TITLE
Add script to build and export knowledge graph from ChromaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,3 +472,57 @@ Found a bug? Have a feature request? Want to contribute?
 *   If you'd like to contribute code, please **fork the repository** and submit a **pull request** with your changes. Ensure your code follows existing style conventions and consider adding tests for new features.
 
 We welcome contributions to improve and expand DiscordSam!
+
+---
+
+## 14. Utility Scripts
+
+This project may include utility scripts for various maintenance or data processing tasks.
+
+### Building a Knowledge Graph (`build_knowledge_graph.py`)
+
+This script allows you to generate a knowledge graph from the structured data (entities and relations) that DiscordSam extracts from conversations and stores in its ChromaDB instance.
+
+**Purpose:**
+
+*   To visualize the relationships and entities the bot has learned.
+*   For data analysis and understanding the bot's knowledge base.
+*   To potentially feed into other graph-based analysis tools.
+
+**Prerequisites:**
+
+*   Ensure you have run DiscordSam and it has processed some conversations, as this script relies on data in the `entities_collection` and `relations_collection` in ChromaDB.
+*   The necessary Python packages must be installed (including `networkx` and `chromadb`, which are in `requirements.txt`).
+
+**How to Run:**
+
+1.  Ensure your virtual environment is activated if you are using one.
+2.  Navigate to the root directory of the DiscordSam project.
+3.  Run the script from your terminal:
+
+    ```bash
+    python build_knowledge_graph.py [options]
+    ```
+
+**Command-Line Options:**
+
+*   `-o <filepath>`, `--output <filepath>`
+    *   Specifies the path and filename for the output graph file.
+    *   The graph is saved in GEXF format, which is compatible with graph visualization software like Gephi.
+    *   **Default:** `knowledge_graph.gexf` (saved in the current working directory).
+    *   Example: `python build_knowledge_graph.py -o ./graphs/my_bot_knowledge.gexf`
+
+**Output:**
+
+*   **A GEXF file:** This file contains the nodes (entities) and edges (relations) of the knowledge graph. You can open this file in tools like [Gephi](https://gephi.org/) to visualize and explore the graph.
+    *   **Nodes:** Represent entities extracted by the bot (e.g., "PersonA", "Python Programming", "ProjectX"). Node attributes include `entity_type` (e.g., "Person", "Concept", "Organization") and `source_doc_id` (linking back to the conversation source).
+    *   **Edges:** Represent relationships between entities (e.g., "PersonA" -_works_for_-> "OrganizationX"). Edge attributes include the `predicate` (the type of relationship, e.g., "works_for", "uses", "developed_by") and `context_phrase` (the sentence snippet from which the relation was inferred).
+*   **Console Logs:** The script will output logs to the console, indicating its progress, the number of entities and relations fetched, the number of nodes and edges added to the graph, and the final location of the saved GEXF file.
+
+**Interpreting the Graph:**
+
+*   When you open the GEXF file in a tool like Gephi:
+    *   You can use layout algorithms (e.g., ForceAtlas2, Fruchterman-Reingold) to arrange the nodes and edges visually.
+    *   Node labels will typically be the entity names. You can often color or size nodes by their `entity_type` attribute.
+    *   Edge labels can be set to display the `predicate` attribute, showing the nature of the relationships.
+    *   Analyzing the graph can reveal clusters of related entities, common relationships, and the overall structure of the bot's learned knowledge.

--- a/build_knowledge_graph.py
+++ b/build_knowledge_graph.py
@@ -1,0 +1,286 @@
+# This script will build a knowledge graph from data stored in ChromaDB.
+# It will fetch entities and relations and construct a graph using networkx.
+
+import logging
+import chromadb
+from typing import Optional, Dict, Any, List
+import networkx as nx # Import networkx
+import argparse # Import argparse
+
+# Attempt to import global config and specific collections from rag_chroma_manager
+try:
+    from config import config
+    # We will define our own collection variables in this script
+except ImportError:
+    print("Error: Could not import 'config' or 'rag_chroma_manager'. "
+          "Ensure these files are in the PYTHONPATH and accessible.")
+    exit(1)
+
+# Configure basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# Global variables for ChromaDB client and collections
+chroma_client: Optional[chromadb.ClientAPI] = None
+entity_collection: Optional[chromadb.Collection] = None
+relation_collection: Optional[chromadb.Collection] = None
+
+def initialize_chromadb_for_graph() -> bool:
+    """
+    Initializes the ChromaDB client and specific collections needed for graph building.
+    """
+    global chroma_client, entity_collection, relation_collection
+
+    if chroma_client:
+        logger.debug("ChromaDB already initialized for graph.")
+        return True
+    try:
+        logger.info(f"Initializing ChromaDB client with path: {config.CHROMA_DB_PATH}")
+        chroma_client = chromadb.PersistentClient(path=config.CHROMA_DB_PATH)
+
+        logger.info(f"Getting ChromaDB entity collection: {config.CHROMA_ENTITIES_COLLECTION_NAME}")
+        entity_collection = chroma_client.get_collection(name=config.CHROMA_ENTITIES_COLLECTION_NAME)
+
+        logger.info(f"Getting ChromaDB relation collection: {config.CHROMA_RELATIONS_COLLECTION_NAME}")
+        relation_collection = chroma_client.get_collection(name=config.CHROMA_RELATIONS_COLLECTION_NAME)
+
+        logger.info(
+            "ChromaDB initialized successfully for graph building. Required collections are accessible."
+        )
+        return True
+    except Exception as e:
+        logger.critical(f"Failed to initialize ChromaDB or get required collections for graph: {e}", exc_info=True)
+        chroma_client = None
+        entity_collection = None
+        relation_collection = None
+        return False
+
+if __name__ == "__main__":
+    logger.info("Starting knowledge graph builder script.")
+    if initialize_chromadb_for_graph():
+        logger.info("ChromaDB initialized successfully.")
+
+        if entity_collection:
+            try:
+                logger.info(f"Fetching all entities from collection: {config.CHROMA_ENTITIES_COLLECTION_NAME}")
+                # Fetch all entries. ChromaDB's get() without IDs or where_document fetches all.
+                # We need documents (entity names) and metadatas (type, etc.)
+                entities_data = entity_collection.get(include=["documents", "metadatas"])
+
+                num_entities = len(entities_data.get("ids", []))
+                logger.info(f"Successfully fetched {num_entities} entities.")
+
+                # Example: Print first few entities if any
+                # for i in range(min(3, num_entities)):
+                #    logger.info(f"Entity ID: {entities_data['ids'][i]}, "
+                #                f"Name: {entities_data['documents'][i]}, "
+                #                f"Metadata: {entities_data['metadatas'][i]}")
+
+            except Exception as e:
+                logger.error(f"Failed to fetch entities: {e}", exc_info=True)
+                entities_data = None # Ensure it's None on failure
+        else:
+            logger.error("Entity collection is not available. Cannot fetch entities.")
+            entities_data = None
+
+        if relation_collection:
+            try:
+                logger.info(f"Fetching all relations from collection: {config.CHROMA_RELATIONS_COLLECTION_NAME}")
+                # Fetch all entries. We need metadatas (subject, predicate, object).
+                # Documents for relations are textual representations like "Subject Predicate Object"
+                relations_data = relation_collection.get(include=["documents", "metadatas"])
+
+                num_relations = len(relations_data.get("ids", []))
+                logger.info(f"Successfully fetched {num_relations} relations.")
+
+                # Example: Print first few relations if any
+                # for i in range(min(3, num_relations)):
+                #    logger.info(f"Relation ID: {relations_data['ids'][i]}, "
+                #                f"Document: {relations_data['documents'][i]}, "
+                #                f"Metadata: {relations_data['metadatas'][i]}")
+
+            except Exception as e:
+                logger.error(f"Failed to fetch relations: {e}", exc_info=True)
+                relations_data = None # Ensure it's None on failure
+        else:
+            logger.error("Relation collection is not available. Cannot fetch relations.")
+            relations_data = None
+
+        # Further steps will go here, using entities_data and relations_data
+
+        graph = nx.DiGraph() # Create a directed graph
+
+        if entities_data and entities_data.get("documents") and entities_data.get("metadatas"):
+            logger.info("Adding entities to the graph...")
+            entity_names = entities_data["documents"]
+            entity_metadatas = entities_data["metadatas"]
+            for i, entity_name in enumerate(entity_names):
+                if entity_name: # Ensure entity_name is not None or empty
+                    metadata = entity_metadatas[i] if entity_metadatas and i < len(entity_metadatas) else {}
+                    graph.add_node(
+                        entity_name,
+                        entity_type=metadata.get("entity_type", "Unknown"),
+                        source_doc_id=metadata.get("source_doc_id", ""),
+                        raw_details=metadata.get("raw_details", "{}")
+                    )
+            logger.info(f"Added {graph.number_of_nodes()} nodes to the graph.")
+        else:
+            logger.warning("No valid entity data to add to the graph.")
+
+        if relations_data and relations_data.get("metadatas"):
+            logger.info("Adding relations to the graph...")
+            relation_metadatas = relations_data["metadatas"]
+            # Documents for relations are also available if needed: relations_data.get("documents")
+
+            edges_added = 0
+            for i, rel_meta in enumerate(relation_metadatas):
+                subject = rel_meta.get("subject_name")
+                predicate = rel_meta.get("predicate")
+                obj = rel_meta.get("object_name")
+
+                if subject and predicate and obj:
+                    # Ensure nodes exist before adding edge, or let networkx create them (default behavior)
+                    # For cleaner graph, prefer nodes to be defined from entity_collection first.
+                    if not graph.has_node(subject):
+                        logger.warning(f"Subject node '{subject}' for relation not found in entities. Adding as a simple node.")
+                        graph.add_node(subject, entity_type="Unknown_From_Relation")
+                    if not graph.has_node(obj):
+                        logger.warning(f"Object node '{obj}' for relation not found in entities. Adding as a simple node.")
+                        graph.add_node(obj, entity_type="Unknown_From_Relation")
+
+                    graph.add_edge(
+                        subject,
+                        obj,
+                        predicate=predicate,
+                        context_phrase=rel_meta.get("context_phrase", ""),
+                        source_doc_id=rel_meta.get("source_doc_id", ""),
+                        raw_details=rel_meta.get("raw_details", "{}")
+                    )
+                    edges_added += 1
+                else:
+                    logger.warning(f"Skipping relation due to missing subject, predicate, or object: {rel_meta}")
+            logger.info(f"Added {edges_added} edges to the graph.")
+            logger.info(f"Graph construction complete. Nodes: {graph.number_of_nodes()}, Edges: {graph.number_of_edges()}")
+
+        else:
+            logger.warning("No valid relation data to add to the graph.")
+
+        if graph.number_of_nodes() > 0 or graph.number_of_edges() > 0:
+            logger.info(f"Final graph: {graph.number_of_nodes()} nodes, {graph.number_of_edges()} edges.")
+
+            # Output: Save to GEXF file
+            output_filename = "knowledge_graph.gexf" # Default filename
+            try:
+                nx.write_gexf(graph, output_filename)
+                logger.info(f"Knowledge graph saved to {output_filename}")
+            except Exception as e:
+                logger.error(f"Failed to save graph to GEXF file: {e}", exc_info=True)
+        else:
+            logger.info("Graph is empty. Nothing to save.")
+
+    else:
+        logger.error("Failed to initialize ChromaDB. Exiting.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Build a knowledge graph from ChromaDB collections.")
+    parser.add_argument(
+        "-o", "--output",
+        default="knowledge_graph.gexf",
+        help="Output file path for the GEXF graph file (default: knowledge_graph.gexf)"
+    )
+    args = parser.parse_args()
+
+    logger.info("Starting knowledge graph builder script.")
+    if initialize_chromadb_for_graph():
+        logger.info("ChromaDB initialized successfully.")
+
+        entities_data = None
+        if entity_collection:
+            try:
+                logger.info(f"Fetching all entities from collection: {config.CHROMA_ENTITIES_COLLECTION_NAME}")
+                entities_data = entity_collection.get(include=["documents", "metadatas"])
+                num_entities = len(entities_data.get("ids", []))
+                logger.info(f"Successfully fetched {num_entities} entities.")
+            except Exception as e:
+                logger.error(f"Failed to fetch entities: {e}", exc_info=True)
+        else:
+            logger.error("Entity collection is not available. Cannot fetch entities.")
+
+        relations_data = None
+        if relation_collection:
+            try:
+                logger.info(f"Fetching all relations from collection: {config.CHROMA_RELATIONS_COLLECTION_NAME}")
+                relations_data = relation_collection.get(include=["documents", "metadatas"])
+                num_relations = len(relations_data.get("ids", []))
+                logger.info(f"Successfully fetched {num_relations} relations.")
+            except Exception as e:
+                logger.error(f"Failed to fetch relations: {e}", exc_info=True)
+        else:
+            logger.error("Relation collection is not available. Cannot fetch relations.")
+
+        graph = nx.DiGraph()
+
+        if entities_data and entities_data.get("documents") and entities_data.get("metadatas"):
+            logger.info("Adding entities to the graph...")
+            entity_names = entities_data["documents"]
+            entity_metadatas = entities_data["metadatas"]
+            for i, entity_name in enumerate(entity_names):
+                if entity_name:
+                    metadata = entity_metadatas[i] if entity_metadatas and i < len(entity_metadatas) else {}
+                    graph.add_node(
+                        entity_name,
+                        entity_type=metadata.get("entity_type", "Unknown"),
+                        source_doc_id=metadata.get("source_doc_id", ""),
+                        raw_details=metadata.get("raw_details", "{}")
+                    )
+            logger.info(f"Added {graph.number_of_nodes()} nodes to the graph.")
+        else:
+            logger.warning("No valid entity data to add to the graph.")
+
+        if relations_data and relations_data.get("metadatas"):
+            logger.info("Adding relations to the graph...")
+            relation_metadatas = relations_data["metadatas"]
+            edges_added = 0
+            for i, rel_meta in enumerate(relation_metadatas):
+                subject = rel_meta.get("subject_name")
+                predicate = rel_meta.get("predicate")
+                obj = rel_meta.get("object_name")
+
+                if subject and predicate and obj:
+                    if not graph.has_node(subject):
+                        logger.warning(f"Subject node '{subject}' for relation not found in entities. Adding as a simple node.")
+                        graph.add_node(subject, entity_type="Unknown_From_Relation")
+                    if not graph.has_node(obj):
+                        logger.warning(f"Object node '{obj}' for relation not found in entities. Adding as a simple node.")
+                        graph.add_node(obj, entity_type="Unknown_From_Relation")
+                    graph.add_edge(
+                        subject,
+                        obj,
+                        predicate=predicate,
+                        context_phrase=rel_meta.get("context_phrase", ""),
+                        source_doc_id=rel_meta.get("source_doc_id", ""),
+                        raw_details=rel_meta.get("raw_details", "{}")
+                    )
+                    edges_added += 1
+                else:
+                    logger.warning(f"Skipping relation due to missing subject, predicate, or object: {rel_meta}")
+            logger.info(f"Added {edges_added} edges to the graph.")
+            logger.info(f"Graph construction complete. Nodes: {graph.number_of_nodes()}, Edges: {graph.number_of_edges()}")
+        else:
+            logger.warning("No valid relation data to add to the graph.")
+
+        if graph.number_of_nodes() > 0 or graph.number_of_edges() > 0:
+            logger.info(f"Final graph: {graph.number_of_nodes()} nodes, {graph.number_of_edges()} edges.")
+            output_filename = args.output # Use filename from command line arguments
+            try:
+                nx.write_gexf(graph, output_filename)
+                logger.info(f"Knowledge graph saved to {output_filename}")
+            except Exception as e:
+                logger.error(f"Failed to save graph to GEXF file: {e}", exc_info=True)
+        else:
+            logger.info("Graph is empty. Nothing to save.")
+    else:
+        logger.error("Failed to initialize ChromaDB. Exiting.")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,9 @@ torch>=2.0.0
 
 chromadb>=0.4.22
 
+# Knowledge Graph construction
+networkx>=3.0
+
 # Automated browser for scraping, headless tasks
 
 playwright>=1.30.0


### PR DESCRIPTION
This commit introduces a new Python script, `build_knowledge_graph.py`, that enables users to generate a knowledge graph from the structured data (entities and relations) stored in the ChromaDB instance populated by DiscordSam.

Key features of the script:
- Connects to ChromaDB using settings from `config.py`.
- Fetches all entries from the entity and relation collections.
- Constructs a directed graph using the `networkx` library:
    - Entities become nodes with attributes like `entity_type` and `source_doc_id`.
    - Relations become edges with attributes like `predicate` and `context_phrase`.
    - Handles cases where entities mentioned in relations might not be in the primary entity collection by adding them as nodes with a distinct type.
- Allows users to specify the output file path via a command-line argument (`-o` or `--output`).
- Saves the graph in GEXF format, suitable for visualization tools like Gephi.
- Includes comprehensive logging for monitoring and troubleshooting.

The `README.md` has been updated with a new section detailing how to run the script, its command-line options, and how to interpret the output. `networkx` has been added to `requirements.txt`.