### PR TITLE
feat: Store RSS summaries in ChromaDB and consume tweets once

### DIFF
--- a/config.py
+++ b/config.py
@@ -113,6 +113,7 @@ class Config:
         self.CHROMA_ENTITIES_COLLECTION_NAME = os.getenv("CHROMA_ENTITIES_COLLECTION_NAME", "entities_collection")
         self.CHROMA_RELATIONS_COLLECTION_NAME = os.getenv("CHROMA_RELATIONS_COLLECTION_NAME", "relations_collection")
         self.CHROMA_OBSERVATIONS_COLLECTION_NAME = os.getenv("CHROMA_OBSERVATIONS_COLLECTION_NAME", "observations_collection")
+        self.CHROMA_RSS_SUMMARY_COLLECTION_NAME = os.getenv("CHROMA_RSS_SUMMARY_COLLECTION_NAME", "rss_summaries") # New collection for RSS summaries
 
         self.USER_PROVIDED_CONTEXT = os.getenv("USER_PROVIDED_CONTEXT", "")
 

--- a/twitter_cache.py
+++ b/twitter_cache.py
@@ -1,0 +1,44 @@
+import json
+import os
+import logging
+from typing import Dict, Set
+
+logger = logging.getLogger(__name__)
+
+CACHE_FILE = os.path.join(os.path.dirname(__file__), "twitter_seen_ids.json")
+
+
+def load_seen_tweet_ids() -> Dict[str, Set[str]]:
+    """Loads seen tweet IDs from the cache file.
+
+    Returns:
+        Dict[str, Set[str]]: A dictionary where keys are usernames and
+                             values are sets of seen tweet IDs for that user.
+                             Returns an empty dict if cache doesn't exist or is invalid.
+    """
+    if os.path.exists(CACHE_FILE):
+        try:
+            with open(CACHE_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, dict):
+                    # Convert lists back to sets
+                    return {user: set(ids) for user, ids in data.items()}
+        except Exception as e:
+            logger.error(f"Failed to load Twitter cache from {CACHE_FILE}: {e}")
+    return {}
+
+
+def save_seen_tweet_ids(data: Dict[str, Set[str]]) -> None:
+    """Saves seen tweet IDs to the cache file.
+
+    Args:
+        data (Dict[str, Set[str]]): A dictionary where keys are usernames
+                                     and values are sets of seen tweet IDs.
+    """
+    try:
+        # Convert sets to lists for JSON serialization
+        serializable_data = {user: list(ids) for user, ids in data.items()}
+        with open(CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(serializable_data, f, indent=2) # Add indent for readability
+    except Exception as e:
+        logger.error(f"Failed to save Twitter cache to {CACHE_FILE}: {e}")


### PR DESCRIPTION
Implements two main features:
1. RSS summaries are now stored in a dedicated ChromaDB collection.
   - Added `CHROMA_RSS_SUMMARY_COLLECTION_NAME` to config.
   - Updated `rag_chroma_manager.py` to initialize and use this new collection.
   - Added `store_rss_summary` function to `rag_chroma_manager.py`.
   - Modified `/rss` command in `discord_commands.py` to call `store_rss_summary`.

2. Tweets are now consumed only once using a caching mechanism.
   - Created `twitter_cache.py` to manage seen tweet IDs (`twitter_seen_ids.json`).
   - Modified `/gettweets` command in `discord_commands.py` to use this cache, ensuring tweets are processed and displayed only if they haven't been seen before for that user.
   - Verified that `web_utils.py`'s `scrape_latest_tweets` provides suitable unique identifiers (tweet_url) for effective caching.