### PR TITLE
Add homefeed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,21 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         *   Embed(s) containing the raw fetched tweets.
         *   A new set of messages (embeds) containing the LLM-generated summary of the tweets. Progress updates are sent during scraping.
 
+*   **`/homefeed [limit]`**
+    *   **Purpose:** Fetches and summarizes tweets from the logged-in X/Twitter home timeline.
+    *   **Arguments:**
+        *   `limit` (Optional, Default: 10): The maximum number of tweets to fetch (max 50).
+    *   **Behavior:**
+        1.  Uses `web_utils.scrape_home_timeline` (Playwright with JS execution) to scrape tweets from `https://x.com/home`.
+        2.  Displays the raw fetched tweets (timestamp, author, content, link) in Discord embeds, chunked if necessary.
+        3.  Sends the text of these tweets to the LLM with a prompt to analyze and summarize the main themes, topics, and overall sentiment.
+        4.  Streams this summary back to the Discord channel as a new message flow.
+        5.  Provides TTS for the summary if enabled.
+        6.  Stores newly fetched tweets in the `CHROMA_TWEETS_COLLECTION_NAME` collection for future retrieval.
+    *   **Output:**
+        *   Embed(s) containing the raw fetched tweets.
+        *   A new set of messages (embeds) containing the LLM-generated summary of the tweets. Progress updates are sent during scraping.
+
 *   **`/ap <image> [user_prompt]`**
     *   **Purpose:** Describes an attached image in the style of an Associated Press (AP) photo caption, with a humorous twist: a randomly chosen celebrity is creatively inserted as the main subject.
     *   **Arguments:**

--- a/web_utils.py
+++ b/web_utils.py
@@ -436,6 +436,159 @@ async def scrape_latest_tweets(username_queried: str, limit: int = 10, progress_
     return tweets_collected[:limit]
 
 
+async def scrape_home_timeline(limit: int = 10, progress_callback: Optional[Callable[[str], Awaitable[None]]] = None) -> List[Dict[str, Any]]:
+    """Scrape tweets from the logged-in home timeline on X/Twitter."""
+    logger.info(f"Scraping last {limit} tweets from the home timeline using Playwright JS execution.")
+
+    tweets_collected: List[Dict[str, Any]] = []
+    seen_tweet_ids: set[str] = set()
+
+    user_data_dir = os.path.join(os.getcwd(), ".pw-profile")
+    profile_dir_usable = True
+    if not os.path.exists(user_data_dir):
+        try:
+            os.makedirs(user_data_dir, exist_ok=True)
+        except OSError:
+            profile_dir_usable = False
+            logger.error("Could not create .pw-profile. Using non-persistent context for tweet scraping.")
+
+    context_manager: Optional[Any] = None
+    browser_instance_st: Optional[Any] = None
+    page: Optional[Any] = None
+    try:
+        async with PLAYWRIGHT_SEM:
+            async with async_playwright() as p:
+                if profile_dir_usable:
+                    context = await p.chromium.launch_persistent_context(
+                        user_data_dir,
+                        headless=config.HEADLESS_PLAYWRIGHT,
+                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                        user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36",
+                        slow_mo=150,
+                    )
+                else:
+                    logger.warning("Using non-persistent context for tweet scraping.")
+                    browser_instance_st = await p.chromium.launch(
+                        headless=config.HEADLESS_PLAYWRIGHT,
+                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                        slow_mo=150,
+                    )
+                    context = await browser_instance_st.new_context(
+                        user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36",
+                    )
+                context_manager = context
+                page = await context_manager.new_page()
+
+                url = "https://x.com/home"
+                logger.info(f"Navigating to Twitter home timeline: {url}")
+                await page.goto(url, timeout=60000, wait_until="domcontentloaded")
+
+                try:
+                    await page.wait_for_selector("article[data-testid='tweet']", timeout=30000)
+                    logger.info("Initial tweet articles detected on home timeline.")
+                    await asyncio.sleep(1.5)
+                    await page.keyboard.press("Escape")
+                    await asyncio.sleep(0.5)
+                    await page.keyboard.press("Escape")
+                except PlaywrightTimeoutError:
+                    logger.warning("Timed out waiting for initial tweet articles on home timeline. Page might be empty or blocked.")
+                    return []
+
+                max_scroll_attempts = limit + 15
+                for scroll_attempt in range(max_scroll_attempts):
+                    if len(tweets_collected) >= limit:
+                        break
+
+                    try:
+                        clicked_count = await page.evaluate(JS_EXPAND_SHOWMORE_TWITTER, 5)
+                        if clicked_count > 0:
+                            logger.info(f"Clicked {clicked_count} 'Show more' elements on Twitter page.")
+                            await asyncio.sleep(1.5 + random.uniform(0.3, 0.9))
+                    except PlaywrightTimeoutError:
+                        logger.warning("Timeout during JS 'Show More' execution on home timeline.")
+                    except Exception as e_sm:
+                        logger.warning(f"JavaScript 'Show More' execution error on home timeline: {e_sm}")
+
+                    extracted_this_round: List[Dict[str, Any]] = []
+                    newly_added_count = 0
+                    try:
+                        extracted_this_round = await page.evaluate(JS_EXTRACT_TWEETS_TWITTER)
+                    except PlaywrightTimeoutError:
+                        logger.warning("Timeout during JS tweet extraction on home timeline.")
+                    except Exception as e_js:
+                        logger.error(f"JavaScript tweet extraction error on home timeline: {e_js}")
+
+                    for data in extracted_this_round:
+                        uid_parts = [
+                            str(data.get("id", "")),
+                            str(data.get("username", "")),
+                            str(data.get("content") or "")[:30],
+                            str(data.get("timestamp", "")),
+                        ]
+                        uid = hashlib.md5("".join(filter(None, uid_parts)).encode("utf-8")).hexdigest()
+
+                        if uid and uid not in seen_tweet_ids:
+                            tweets_collected.append(data)
+                            seen_tweet_ids.add(uid)
+                            newly_added_count += 1
+                            if progress_callback:
+                                try:
+                                    await progress_callback(f"Scraped {len(tweets_collected)}/{limit} tweets from home timeline...")
+                                except Exception as e_cb:
+                                    logger.warning(f"Progress callback error: {e_cb}")
+                            if len(tweets_collected) >= limit:
+                                break
+
+                    if newly_added_count == 0 and scroll_attempt > (limit // 2 + 7):
+                        logger.info("No new unique tweets found in several scroll attempts. Stopping.")
+                        if progress_callback:
+                            await progress_callback(
+                                f"Stopping early: No new unique tweets found after {scroll_attempt + 1} scrolls. Collected {len(tweets_collected)}."
+                            )
+                        break
+
+                    try:
+                        await page.evaluate("window.scrollBy(0, window.innerHeight * 1.5);")
+                        await asyncio.sleep(random.uniform(3.0, 5.0))
+                    except PlaywrightTimeoutError:
+                        logger.warning("Timeout during page scroll on home timeline. Assuming end of content or page issue.")
+                        break
+
+    except PlaywrightTimeoutError as e:
+        logger.warning(f"Playwright overall timeout during tweet scraping for home timeline: {e}")
+        if progress_callback:
+            await progress_callback(
+                f"Tweet scraping for home timeline timed out overall. Collected {len(tweets_collected)}."
+            )
+    except Exception as e:
+        logger.error(f"Unexpected error during tweet scraping for home timeline: {e}", exc_info=True)
+        if progress_callback:
+            await progress_callback(
+                f"An unexpected error occurred while scraping tweets for home timeline. Collected {len(tweets_collected)}."
+            )
+    finally:
+        if page and not page.is_closed():
+            try:
+                await page.close()
+            except Exception as e_page_close_final:
+                logger.debug(f"Ignoring error closing page (final) for home timeline: {e_page_close_final}")
+        if context_manager:
+            try:
+                await context_manager.close()
+            except Exception as e_ctx_final:
+                if "Target page, context or browser has been closed" not in str(e_ctx_final):
+                    logger.debug(f"Error closing context (final) for home timeline: {e_ctx_final}")
+        if browser_instance_st and not profile_dir_usable:
+            try:
+                await browser_instance_st.close()
+            except Exception as e_browser_final:
+                logger.debug(f"Ignoring error closing browser (final) for home timeline: {e_browser_final}")
+
+    tweets_collected.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
+    logger.info(f"Finished scraping. Collected {len(tweets_collected)} unique tweets from home timeline.")
+    return tweets_collected[:limit]
+
+
 async def query_searx(query: str) -> List[Dict[str, Any]]:
     logger.info(f"Querying Searx for: '{query}'")
     params: Dict[str, Any] = {'q': query, 'format': 'json', 'language': 'en-US'}


### PR DESCRIPTION
## Summary
- add `scrape_home_timeline` to gather tweets from https://x.com/home
- create `/homefeed` command to summarize home timeline tweets
- document new command in README

## Testing
- `python -m py_compile *.py`
- `python -m py_compile web_utils.py discord_commands.py`

------
https://chatgpt.com/codex/tasks/task_e_686bba0b92ec8328924cf374cf98b747