### PR TITLE
Add TTS lock for sequential playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
 *   **Text-to-Speech (TTS):**
     *   Voice responses for bot messages via an OpenAI TTS API compatible server.
     *   Separate TTS for "thoughts" (content within `<think>...</think>` tags) vs. main response if configured.
+    *   TTS operations are queued so only one audio clip plays at a time.
 *   **Slash Commands:** A comprehensive suite of commands for various functionalities (detailed in section 8).
 *   **High Configurability:** Most settings are managed via a `.env` file, allowing for easy customization of LLM endpoints, API keys, and bot behavior.
 *   **Modular Codebase:** Refactored into multiple Python files for better organization, maintainability, and scalability.
@@ -355,7 +356,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
     *   **Purpose:** Fetches new entries from a specified RSS feed, scrapes the linked articles, summarizes them, and displays the summaries.
     *   **Arguments:**
         *   `feed_url` (Required): The URL of the RSS feed. Can be selected from a preset list or provided directly.
-        *   `limit` (Optional, Default: 5): The maximum number of new entries to fetch and process (max 10).
+        *   `limit` (Optional, Default: 15): The maximum number of new entries to fetch and process (max 20).
     *   **Behavior:**
         1.  Fetches the RSS feed using `web_utils.fetch_rss_entries`.
         2.  Compares entries against a local cache (`rss_seen.json`) to identify new ones.
@@ -367,6 +368,16 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         6.  Provides TTS for the combined summaries if enabled.
         7.  The user's command and the bot's full summarized response are added to short-term history and ingested into ChromaDB.
     *   **Output:** One or more embed messages containing summaries of new RSS feed entries.
+
+*   **`/allrss [limit]`**
+    *   **Purpose:** Sequentially processes all default RSS feeds, fetching new entries in batches until no unseen items remain.
+    *   **Arguments:**
+        *   `limit` (Optional, Default: 15): Number of new entries to fetch from each feed per batch (max 20).
+    *   **Behavior:**
+        1.  Iterates over every feed available in the `/rss` command's preset list.
+        2.  For each feed, repeatedly fetches up to `limit` unseen entries, scrapes and summarizes them like `/rss`.
+        3.  Continues processing a feed until it reports "No new entries found." before moving to the next one.
+    *   **Output:** Embeds containing summaries for each batch of articles across all feeds until all are up to date.
 
 *   **`/gettweets [username] [preset_user] [limit]`**
     *   **Purpose:** Fetches and summarizes recent tweets from a specified X/Twitter user.

--- a/audio_utils.py
+++ b/audio_utils.py
@@ -17,7 +17,10 @@ from utils import clean_text_for_tts
 
 logger = logging.getLogger(__name__)
 
-WHISPER_MODEL: Optional[Any] = None 
+# Global lock to ensure TTS requests are processed sequentially.
+TTS_LOCK = asyncio.Lock()
+
+WHISPER_MODEL: Optional[Any] = None
 
 def load_whisper_model() -> Optional[Any]: 
     global WHISPER_MODEL
@@ -109,29 +112,37 @@ async def _send_audio_segment(
     else:
         logger.warning(f"TTS request failed for '{filename_suffix}' segment, no audio data received.")
 
-async def send_tts_audio( # Ensure this function is defined at the module level
-    destination: Union[discord.abc.Messageable, discord.Interaction, discord.Message], 
-    text_to_speak: str, 
+async def send_tts_audio(
+    destination: Union[discord.abc.Messageable, discord.Interaction, discord.Message],
+    text_to_speak: str,
     base_filename: str = "response"
-):
+) -> None:
+    """Generate TTS audio and send it to the given destination.
+
+    The global ``TTS_LOCK`` ensures that only one TTS request is processed at a
+    time so audio playback doesn't overlap when multiple commands trigger TTS
+    concurrently.
+    """
     if not config.TTS_ENABLED_DEFAULT or not text_to_speak:
         return
 
-    think_pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE) # 're' is now imported
-    match = think_pattern.search(text_to_speak)
+    # Serialize TTS processing so audio messages don't overlap
+    async with TTS_LOCK:
+        think_pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL | re.IGNORECASE)
+        match = think_pattern.search(text_to_speak)
 
-    if match:
-        thought_text = match.group(1).strip()
-        response_text = think_pattern.sub('', text_to_speak).strip() 
-        
-        logger.info("Found <think> tags. Processing thoughts and response separately for TTS.")
-        await _send_audio_segment(destination, thought_text, "thoughts", is_thought=True, base_filename=base_filename)
-        await asyncio.sleep(0.5) 
-        if response_text: 
-            await _send_audio_segment(destination, response_text, "main_response", is_thought=False, base_filename=base_filename)
-    else:
-        logger.info("No <think> tags found. Processing full text for TTS.")
-        await _send_audio_segment(destination, text_to_speak, "full", is_thought=False, base_filename=base_filename)
+        if match:
+            thought_text = match.group(1).strip()
+            response_text = think_pattern.sub('', text_to_speak).strip()
+
+            logger.info("Found <think> tags. Processing thoughts and response separately for TTS.")
+            await _send_audio_segment(destination, thought_text, "thoughts", is_thought=True, base_filename=base_filename)
+            await asyncio.sleep(0.5)
+            if response_text:
+                await _send_audio_segment(destination, response_text, "main_response", is_thought=False, base_filename=base_filename)
+        else:
+            logger.info("No <think> tags found. Processing full text for TTS.")
+            await _send_audio_segment(destination, text_to_speak, "full", is_thought=False, base_filename=base_filename)
 
 def transcribe_audio_file(file_path: str) -> Optional[str]:
     if not os.path.exists(file_path):

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -101,6 +101,122 @@ llm_client_instance: Optional[Any] = None
 bot_state_instance: Optional[BotState] = None
 
 
+async def process_rss_feed(
+    interaction: discord.Interaction,
+    feed_url: str,
+    limit: int,
+) -> bool:
+    """Fetch, summarize and display new entries from a single RSS feed.
+
+    Parameters
+    ----------
+    interaction : discord.Interaction
+        The originating interaction for responding and context.
+    feed_url : str
+        RSS feed URL to process.
+    limit : int
+        Maximum number of new entries to process in this batch.
+
+    Returns
+    -------
+    bool
+        ``True`` if any new entries were processed, ``False`` otherwise.
+    """
+
+    progress_message = await interaction.followup.send(
+        content=f"Fetching RSS feed: {feed_url}..."
+    )
+
+    seen = load_seen_entries()
+    seen_ids = set(seen.get(feed_url, []))
+
+    entries = await fetch_rss_entries(feed_url)
+    new_entries = [e for e in entries if e.get("guid") not in seen_ids]
+    if not new_entries:
+        await progress_message.edit(content="No new entries found.")
+        return False
+
+    to_process = new_entries[:limit]
+    summaries: List[str] = []
+
+    for idx, ent in enumerate(to_process, 1):
+        title = ent.get("title") or "Untitled"
+        link = ent.get("link") or ""
+        guid = ent.get("guid") or link
+
+        await progress_message.edit(
+            content=f"Scraping {idx}/{len(to_process)}: {title}..."
+        )
+
+        scraped_text, _ = await scrape_website(link)
+        if not scraped_text or "Failed to scrape" in scraped_text or "Scraping timed out" in scraped_text:
+            summaries.append(f"**{title}**\nCould not scrape article: {link}\n")
+            seen_ids.add(guid)
+            continue
+
+        prompt = (
+            "It is 2025 and Donald Trump is the current president (Just an FYI. Maybe unrelated to context and omitted). "
+            "Do not use em dashes, favoring commas or regular dashes. Summarize the following article in 2-4 sentences. "
+            "Focus on key facts. Present in a casual, blunt, honest and slightly profane tone. Do not start with 'So, '.\n\n"
+            f"Title: {title}\nURL: {link}\n\n{scraped_text[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}"
+        )
+
+        try:
+            response = await llm_client_instance.chat.completions.create(
+                model=config.FAST_LLM_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=500,
+                temperature=0.5,
+                stream=False,
+            )
+            summary = response.choices[0].message.content.strip() if response.choices else ""
+            if summary and summary != "[LLM summarization failed]":
+                store_rss_summary(
+                    feed_url=feed_url,
+                    article_url=link,
+                    title=title,
+                    summary_text=summary,
+                    timestamp=datetime.now(),
+                )
+        except Exception as e_summ:
+            logger.error(f"LLM summarization failed for {link}: {e_summ}")
+            summary = "[LLM summarization failed]"
+
+        summaries.append(f"**{title}**\n{summary}\n{link}\n")
+        seen_ids.add(guid)
+
+    seen[feed_url] = list(seen_ids)
+    save_seen_entries(seen)
+
+    combined = "\n\n".join(summaries)
+    chunks = chunk_text(combined, config.EMBED_MAX_LENGTH)
+    for i, chunk in enumerate(chunks):
+        embed = discord.Embed(
+            title=f"RSS Summaries for {feed_url}" + ("" if i == 0 else f" (cont. {i+1})"),
+            description=chunk,
+            color=config.EMBED_COLOR["complete"],
+        )
+        if i == 0:
+            await progress_message.edit(content=None, embed=embed)
+        else:
+            await interaction.followup.send(embed=embed)
+
+    await send_tts_audio(interaction, combined, base_filename=f"rss_{interaction.id}")
+
+    user_msg = MsgNode("user", f"/rss {feed_url} (limit {limit})", name=str(interaction.user.id))
+    assistant_msg = MsgNode("assistant", combined, name=str(bot_instance.user.id))
+    await bot_state_instance.append_history(interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY)
+    await bot_state_instance.append_history(interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY)
+    await ingest_conversation_to_chromadb(
+        llm_client_instance,
+        interaction.channel_id,
+        interaction.user.id,
+        [user_msg, assistant_msg],
+    )
+
+    return True
+
+
 def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState):
     global bot_instance, llm_client_instance, bot_state_instance
     bot_instance = bot
@@ -643,7 +759,6 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
 
         scrape_lock = bot_state_instance.get_scrape_lock()
         queue_notice = scrape_lock.locked()
-        progress_message: discord.Message
         acquired_lock = False
         if queue_notice:
             await interaction.response.send_message(
@@ -652,119 +767,64 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             )
             await scrape_lock.acquire()
             acquired_lock = True
-            progress_message = await interaction.followup.send(
-                content=f"Fetching RSS feed: {final_feed_url}...",
-            )
         else:
             await scrape_lock.acquire()
             acquired_lock = True
             await interaction.response.defer(ephemeral=False)
-            progress_message = await interaction.edit_original_response(
-                content=f"Fetching RSS feed: {final_feed_url}..."
-            )
-
-        async def _process_rss(progress_msg: discord.Message) -> None:
-            seen = load_seen_entries()
-            seen_ids = set(seen.get(final_feed_url, [])) # Use final_feed_url
-
-            entries = await fetch_rss_entries(final_feed_url) # Use final_feed_url
-            new_entries = [e for e in entries if e.get("guid") not in seen_ids]
-            if not new_entries:
-                await progress_msg.edit(content="No new entries found.")
-                return
-
-            to_process = new_entries[:limit]
-            summaries: List[str] = []
-
-            for idx, ent in enumerate(to_process, 1):
-                title = ent.get("title") or "Untitled"
-                link = ent.get("link") or ""
-                guid = ent.get("guid") or link
-
-                await progress_msg.edit(content=f"Scraping {idx}/{len(to_process)}: {title}...")
-
-                scraped_text, _ = await scrape_website(link)
-                if not scraped_text or "Failed to scrape" in scraped_text or "Scraping timed out" in scraped_text:
-                    summaries.append(f"**{title}**\nCould not scrape article: {link}\n")
-                    seen_ids.add(guid)
-                    continue
-
-                prompt = (
-                    f"It is 2025 and Donald Trump is the current president (Just an FYI. Maybe unrelated to context and omitted). Do not use em dashes, favoring commas or regular dashes. Summarize the following article in 2-4 sentences. Focus on key facts. Present in a casual, blunt, honest and slightly profane tone. Do not start with 'So, '.\n\n"
-                    f"Title: {title}\nURL: {link}\n\n{scraped_text[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}"
-                )
-
-                try:
-                    response = await llm_client_instance.chat.completions.create(
-                        model=config.FAST_LLM_MODEL,
-                        messages=[{"role": "user", "content": prompt}],
-                        max_tokens=500,
-                        temperature=0.5,
-                        stream=False,
-                    )
-                    summary = response.choices[0].message.content.strip() if response.choices else ""
-                    if summary and summary != "[LLM summarization failed]":
-                        # Store the successful summary in ChromaDB
-                        store_rss_summary(
-                            feed_url=final_feed_url, # Use final_feed_url
-                            article_url=link,
-                            title=title,
-                            summary_text=summary,
-                            timestamp=datetime.now() #  ent.get("published_parsed") could be used if available and reliable
-                        )
-                except Exception as e_summ:
-                    logger.error(f"LLM summarization failed for {link}: {e_summ}")
-                    summary = "[LLM summarization failed]"
-
-                summaries.append(f"**{title}**\n{summary}\n{link}\n")
-                seen_ids.add(guid)
-
-            seen[final_feed_url] = list(seen_ids) # Use final_feed_url
-            save_seen_entries(seen)
-
-            combined = "\n\n".join(summaries)
-            chunks = chunk_text(combined, config.EMBED_MAX_LENGTH)
-            for i, chunk in enumerate(chunks):
-                embed = discord.Embed(
-                    title=f"RSS Summaries for {final_feed_url}" + ("" if i == 0 else f" (cont. {i+1})"), # Use final_feed_url
-                    description=chunk,
-                    color=config.EMBED_COLOR["complete"],
-                )
-                if i == 0:
-                    await progress_msg.edit(content=None, embed=embed)
-                else:
-                    await interaction.followup.send(embed=embed)
-
-            # --- New: Postprocess like other responses ---
-            await send_tts_audio(interaction, combined, base_filename=f"rss_{interaction.id}")
-            user_msg = MsgNode(
-                "user",
-                f"/rss {final_feed_url} (limit {limit})", # Use final_feed_url
-                name=str(interaction.user.id),
-            )
-            assistant_msg = MsgNode(
-                "assistant",
-                combined,
-                name=str(bot_instance.user.id),
-            )
-            await bot_state_instance.append_history(
-                interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY
-            )
-            await bot_state_instance.append_history(
-                interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY
-            )
-            await ingest_conversation_to_chromadb(
-                llm_client_instance,
-                interaction.channel_id,
-                interaction.user.id,
-                [user_msg, assistant_msg],
-            )
 
         try:
-            await _process_rss(progress_message)
+            await process_rss_feed(interaction, final_feed_url, limit)
         except Exception as e:
-            logger.error(f"Error in rss_slash_command for {final_feed_url}: {e}", exc_info=True) # Use final_feed_url
-            await progress_message.edit(content=f"Failed to process RSS feed. Error: {str(e)[:500]}", embed=None)
+            logger.error(f"Error in rss_slash_command for {final_feed_url}: {e}", exc_info=True)
+            await interaction.followup.send(content=f"Failed to process RSS feed. Error: {str(e)[:500]}")
+        finally:
+            if acquired_lock:
+                scrape_lock.release()
+
+    @bot_instance.tree.command(name="allrss", description="Fetches new entries from all default RSS feeds until up to date.")
+    @app_commands.describe(
+        limit="Number of new entries per feed to fetch at a time (max 20)."
+    )
+    async def allrss_slash_command(
+        interaction: discord.Interaction,
+        limit: app_commands.Range[int, 1, 20] = 15,
+    ) -> None:
+        if not llm_client_instance or not bot_state_instance or not bot_instance or not bot_instance.user:
+            logger.error("allrss_slash_command: One or more bot components are None.")
+            await interaction.response.send_message("Bot components not ready. Cannot fetch RSS.", ephemeral=True)
+            return
+
+        if interaction.channel_id is None:
+            await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
+            return
+
+        scrape_lock = bot_state_instance.get_scrape_lock()
+        queue_notice = scrape_lock.locked()
+        acquired_lock = False
+        if queue_notice:
+            await interaction.response.send_message(
+                "Waiting for other scraping tasks to finish before processing all RSS feeds...",
+                ephemeral=True,
+            )
+            await scrape_lock.acquire()
+            acquired_lock = True
+            await interaction.followup.send(content="Starting RSS feed processing...")
+        else:
+            await scrape_lock.acquire()
+            acquired_lock = True
+            await interaction.response.defer(ephemeral=False)
+            await interaction.followup.send(content="Starting RSS feed processing...")
+
+        try:
+            for name, feed_url in DEFAULT_RSS_FEEDS:
+                logger.info(f"Processing RSS feed: {name} ({feed_url})")
+                while True:
+                    processed = await process_rss_feed(interaction, feed_url, limit)
+                    if not processed:
+                        break
+        except Exception as e:
+            logger.error(f"Error in allrss_slash_command: {e}", exc_info=True)
+            await interaction.followup.send(content=f"Failed to process RSS feeds. Error: {str(e)[:500]}")
         finally:
             if acquired_lock:
                 scrape_lock.release()


### PR DESCRIPTION
## Summary
- ensure only one TTS request runs at a time
- protect `/rss` and `/allrss` TTS output from overlapping
- send a new message for each RSS batch instead of editing progress
- update RSS progress behavior so updates edit a single message per feed

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686cdda8b50c8328b535d9b63bd9a1ae