### PR TITLE
Add publication date to RSS summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,12 +363,12 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         3.  For each new entry (up to `limit`):
             *   Scrapes the content of the article linked in the entry.
             *   Uses a fast LLM (`FAST_LLM_MODEL`) to summarize the scraped article.
-        4.  Displays the summaries (title, summary, link) in Discord embeds. If the content is long, it's chunked into multiple embeds.
+        4.  Displays the summaries (title, publication date, link, summary) in Discord embeds. If the content is long, it's chunked into multiple embeds.
         5.  Updates the `rss_seen.json` cache.
         6.  Provides TTS for the combined summaries if enabled.
         7.  The user's command and the bot's full summarized response are added to short-term history and ingested into ChromaDB.
         8.  If no new entries are found, the bot replies with an ephemeral message instead of posting publicly.
-    *   **Output:** One or more embed messages containing summaries of new RSS feed entries.
+    *   **Output:** One or more embed messages containing summaries of new RSS feed entries, with each entry showing the title, publication date, link, and summary.
 
 *   **`/allrss [limit]`**
     *   **Purpose:** Sequentially processes all default RSS feeds, fetching new entries in batches until no unseen items remain.

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -145,6 +145,7 @@ async def process_rss_feed(
 
     for idx, ent in enumerate(to_process, 1):
         title = ent.get("title") or "Untitled"
+        pub_date = ent.get("pubDate") or ""
         link = ent.get("link") or ""
         guid = ent.get("guid") or link
 
@@ -154,7 +155,7 @@ async def process_rss_feed(
 
         scraped_text, _ = await scrape_website(link)
         if not scraped_text or "Failed to scrape" in scraped_text or "Scraping timed out" in scraped_text:
-            summaries.append(f"**{title}**\nCould not scrape article: {link}\n")
+            summaries.append(f"**{title}**\n{pub_date}\n{link}\nCould not scrape article\n")
             seen_ids.add(guid)
             continue
 
@@ -186,7 +187,7 @@ async def process_rss_feed(
             logger.error(f"LLM summarization failed for {link}: {e_summ}")
             summary = "[LLM summarization failed]"
 
-        summaries.append(f"**{title}**\n{summary}\n{link}\n")
+        summaries.append(f"**{title}**\n{pub_date}\n{link}\n{summary}\n")
         seen_ids.add(guid)
 
     seen[feed_url] = list(seen_ids)


### PR DESCRIPTION
## Summary
- include `pubDate` from RSS items when creating summaries
- show title, publication date, link, and summary in that order
- update README to reflect new format

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfa38e4208328889fd4c0d3bbbfe4