### PR TITLE
Fix ephemeral fallback to channel.send

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -109,7 +109,9 @@ async def safe_followup_send(
                 "Interaction token expired%s; falling back to channel.send", " " + error_hint if error_hint else ""
             )
             if interaction.channel:
-                return await interaction.channel.send(**kwargs)
+                kwargs_no_ephemeral = dict(kwargs)
+                kwargs_no_ephemeral.pop("ephemeral", None)
+                return await interaction.channel.send(**kwargs_no_ephemeral)
         raise
 
 


### PR DESCRIPTION
## Summary
- handle ephemeral param in `safe_followup_send` when falling back to `channel.send`

## Testing
- `python -m py_compile utils.py`

------
https://chatgpt.com/codex/tasks/task_e_686d9501b8ec8328ab4cffa47bc269c4