### PR TITLE
Implement memory merging with latest conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ DiscordSam is a modular Python application designed for extensibility and mainta
     *   `initialize_chromadb()`: Sets up connections to various data collections (raw history, distilled summaries, news, timeline summaries, entities, relations, observations).
     *   `ingest_conversation_to_chromadb()`: Stores new conversations, extracts structured data (entities, relations, observations), distills key sentences, and saves them for future retrieval.
     *   `retrieve_and_prepare_rag_context()`: Given a query, searches relevant collections for pertinent information and synthesizes it into a context string for the LLM.
+    *   `update_retrieved_memories()`: Merges retrieved memory snippets with the latest conversation summary and stores updated memories for future use.
     *   Includes functions for importing data (e.g., ChatGPT exports) and storing specific data types (e.g., news summaries).
 
 8.  **Utility Modules**:

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -237,6 +237,7 @@ async def process_rss_feed(
         interaction.channel_id,
         interaction.user.id,
         [user_msg, assistant_msg],
+        None,
     )
 
     return True
@@ -404,7 +405,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 prompt_messages=prompt_nodes_for_briefing,
                 title=f"News Briefing: {topic}",
                 synthesized_rag_context_for_display=synthesized_summary_for_briefing,
-                bot_user_id=bot_instance.user.id
+                bot_user_id=bot_instance.user.id,
+                retrieved_snippets=raw_snippets_for_briefing,
             )
 
         except Exception as e:
@@ -537,7 +539,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 interaction, llm_client_instance, bot_state_instance, user_msg_node, prompt_nodes,
                 title=f"Comedy Roast of {url}",
                 synthesized_rag_context_for_display=synthesized_summary,
-                bot_user_id=bot_instance.user.id
+                bot_user_id=bot_instance.user.id,
+                retrieved_snippets=raw_snippets
             )
         except Exception as e:
             logger.error(f"Error in roast_slash_command for URL '{url}': {e}", exc_info=True)
@@ -681,7 +684,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 title=f"Summary for Search: {query}",
                 force_new_followup_flow=True,
                 synthesized_rag_context_for_display=synthesized_summary,
-                bot_user_id=bot_instance.user.id
+                bot_user_id=bot_instance.user.id,
+                retrieved_snippets=raw_snippets
             )
         except Exception as e:
             logger.error(f"Error in search_slash_command for query '{query}': {e}", exc_info=True)
@@ -738,7 +742,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 interaction, llm_client_instance, bot_state_instance, user_msg_node, final_prompt_nodes,
                 title="Sarcastic Political Commentary",
                 synthesized_rag_context_for_display=synthesized_summary,
-                bot_user_id=bot_instance.user.id
+                bot_user_id=bot_instance.user.id,
+                retrieved_snippets=raw_snippets
             )
         except Exception as e:
             logger.error(f"Error in pol_slash_command for statement '{statement[:50]}...': {e}", exc_info=True)
@@ -1117,7 +1122,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 title=f"Tweet Summary for @{clean_username}",
                 force_new_followup_flow=True,
                 synthesized_rag_context_for_display=synthesized_summary,
-                bot_user_id=bot_instance.user.id
+                bot_user_id=bot_instance.user.id,
+                retrieved_snippets=raw_snippets
             )
         except Exception as e:
             logger.error(
@@ -1358,7 +1364,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 title="Tweet Summary for Home Timeline",
                 force_new_followup_flow=True,
                 synthesized_rag_context_for_display=synthesized_summary,
-                bot_user_id=bot_instance.user.id
+                bot_user_id=bot_instance.user.id,
+                retrieved_snippets=raw_snippets
             )
         except Exception as e:
             logger.error(
@@ -1450,7 +1457,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 interaction, llm_client_instance, bot_state_instance, user_msg_node, final_prompt_nodes,
                 title=f"AP Photo Description ft. {chosen_celebrity} or someone associted with them.",
                 synthesized_rag_context_for_display=synthesized_summary,
-                bot_user_id=bot_instance.user.id
+                bot_user_id=bot_instance.user.id,
+                retrieved_snippets=raw_snippets,
             )
         except Exception as e:
             logger.error(f"Error in ap_slash_command for image '{image.filename}': {e}", exc_info=True)

--- a/discord_events.py
+++ b/discord_events.py
@@ -435,7 +435,8 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
             user_msg_node=user_msg_node_for_short_term_history,
             prompt_messages=llm_prompt_for_current_turn,
             synthesized_rag_context_for_display=synthesized_rag_summary, # Display summary
-            bot_user_id=bot_instance.user.id
+            bot_user_id=bot_instance.user.id,
+            retrieved_snippets=raw_rag_snippets,
         )
 
     # ... (on_raw_reaction_add, on_app_command_error, on_command_error remain the same)

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -411,7 +411,8 @@ async def stream_llm_response_to_interaction(
     title: str = "Sam's Response",
     force_new_followup_flow: bool = False,
     synthesized_rag_context_for_display: Optional[str] = None,
-    bot_user_id: Optional[int] = None
+    bot_user_id: Optional[int] = None,
+    retrieved_snippets: Optional[List[Tuple[str, str]]] = None
 ):
     channel_lock = None
     if interaction.channel_id is not None:
@@ -546,6 +547,7 @@ async def stream_llm_response_to_interaction(
             channel_id,
             interaction.user.id,
             chroma_ingest_history_with_response,
+            retrieved_snippets,
         )
 
 
@@ -557,7 +559,8 @@ async def stream_llm_response_to_message(
     prompt_messages: List[MsgNode],
     title: str = "Sam's Response",
     synthesized_rag_context_for_display: Optional[str] = None,
-    bot_user_id: Optional[int] = None
+    bot_user_id: Optional[int] = None,
+    retrieved_snippets: Optional[List[Tuple[str, str]]] = None
 ):
     channel_lock = bot_state.get_channel_lock(target_message.channel.id)
     initial_embed = discord.Embed(title=title, description="⏳ Thinking...", color=config.EMBED_COLOR["incomplete"])
@@ -624,6 +627,7 @@ async def stream_llm_response_to_message(
             channel_id,
             target_message.author.id,
             chroma_ingest_history_with_response,
+            retrieved_snippets,
         )
 
 


### PR DESCRIPTION
## Summary
- add helper functions to merge retrieved memories with new conversation summaries
- update `ingest_conversation_to_chromadb` to accept retrieved snippets and store merged memories
- extend streaming helpers to pass retrieved snippets from commands/events
- document `update_retrieved_memories` in README

## Testing
- `python -m py_compile rag_chroma_manager.py llm_handling.py discord_commands.py discord_events.py`

------
https://chatgpt.com/codex/tasks/task_e_686f5ebaaa4c8328adb8f6c1c374e661