### PR TITLE
Add temporal context to memory merging and RAG synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ DiscordSam is a modular Python application designed for extensibility and mainta
     *   Manages the Retrieval Augmented Generation pipeline and all interactions with the ChromaDB vector store.
     *   `initialize_chromadb()`: Sets up connections to various data collections (raw history, distilled summaries, news, timeline summaries, entities, relations, observations).
     *   `ingest_conversation_to_chromadb()`: Stores new conversations, extracts structured data (entities, relations, observations), distills key sentences, and saves them for future retrieval.
-    *   `retrieve_and_prepare_rag_context()`: Given a query, searches relevant collections for pertinent information and synthesizes it into a context string for the LLM.
-    *   `update_retrieved_memories()`: Merges retrieved memory snippets with the latest conversation summary and stores updated memories for future use.
+    *   `retrieve_and_prepare_rag_context()`: Given a query, searches relevant collections for pertinent information and synthesizes it into a context string for the LLM. The synthesis step now receives the current date so it can express how long ago memories occurred.
+    *   `update_retrieved_memories()`: Merges retrieved memory snippets with the latest conversation summary and stores updated memories for future use. The merge prompt now includes both the snippet's original date and the current date, giving the LLM clearer temporal context.
     *   Includes functions for importing data (e.g., ChatGPT exports) and storing specific data types (e.g., news summaries).
 
 8.  **Utility Modules**:

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -298,7 +298,10 @@ async def synthesize_retrieved_contexts_llm(llm_client: Any, retrieved_contexts:
     for i, (text, source_name) in enumerate(retrieved_contexts):
         formatted_snippets += f"--- Memory {i+1} (from: {source_name}) ---\n{text[:2000]}\n\n"
 
+    current_date_str = datetime.now().isoformat()
+
     prompt = (
+        f"CURRENT DATE: {current_date_str}\n"
         "You are a master context synthesizer. Below are several retrieved conversation snippets (refer to these as memories) that "
         "might be relevant to the user's current query. Your task is to read all of them and synthesize "
         "a single, concise yet detailed paragraph that captures the most relevant information from these memories "
@@ -354,8 +357,14 @@ async def merge_memory_snippet_with_summary_llm(
         "Return 1-3 concise sentences that preserve important older details and incorporate the new information." 
     )
 
+    timestamp_match = re.search(r"Conversation recorded at:\s*(.+)", old_memory)
+    old_date_str = timestamp_match.group(1).strip() if timestamp_match else "unknown"
+    current_date_str = datetime.now().isoformat()
+
     user_text = (
-        f"EXISTING MEMORY:\n{old_memory}\n\nNEW CONVERSATION SUMMARY:\n{new_summary}\n\nUPDATED MEMORY:" 
+        f"OLD MEMORY DATE: {old_date_str}\n"
+        f"CURRENT DATE: {current_date_str}\n"
+        f"EXISTING MEMORY:\n{old_memory}\n\nNEW CONVERSATION SUMMARY:\n{new_summary}\n\nUPDATED MEMORY:"
     )
 
     try:


### PR DESCRIPTION
## Summary
- include old and current dates when merging memory snippets
- let RAG context synthesis know today's date
- document these temporal improvements in README

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_686f6b2ed29083289a0e34093b6c8594