### PR TITLE
Handle Daily Beast paywall

### DIFF
--- a/web_utils.py
+++ b/web_utils.py
@@ -172,8 +172,17 @@ async def scrape_website(
     progress_callback: Optional[Callable[[str], Awaitable[None]]] = None,
     screenshots_dir: Optional[str] = None
 ) -> Tuple[Optional[str], List[str]]:
-    if url.startswith("https://www.nytimes.com/") or url.startswith("https://www.wsj.com/"):
-        archive_domain = "NYTimes" if "nytimes.com" in url else "WSJ"
+    if (
+        url.startswith("https://www.nytimes.com/")
+        or url.startswith("https://www.wsj.com/")
+        or url.startswith("https://www.thedailybeast.com/")
+    ):
+        if "nytimes.com" in url:
+            archive_domain = "NYTimes"
+        elif "wsj.com" in url:
+            archive_domain = "WSJ"
+        else:
+            archive_domain = "DailyBeast"
         url = f"https://archive.is/newest/{url}"
         logger.info(f"{archive_domain} URL detected. Using archive.is: {url}")
     logger.info(f"Attempting to scrape website: {url}")


### PR DESCRIPTION
## Summary
- update `scrape_website` to treat `thedailybeast.com` as a paywalled site and fetch via `archive.is`

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6874327816988328bbfbec9fc374212d