### PR TITLE
Resolve Google redirect URLs in RSS entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,16 +361,17 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         *   `limit` (Optional, Default: 15): The maximum number of new entries to fetch and process (max 20).
     *   **Behavior:**
         1.  Fetches the RSS feed using `web_utils.fetch_rss_entries`.
-        2.  Skips CBS News entries from `https://www.cbsnews.com/video/` as these pages lack article text.
-        3.  Compares entries against a local cache (`rss_seen.json`) to identify new ones.
-        4.  For each new entry (up to `limit`):
+        2.  Resolves Google redirect URLs so the final article link is shown instead of a long Google URL.
+        3.  Skips CBS News entries from `https://www.cbsnews.com/video/` as these pages lack article text.
+        4.  Compares entries against a local cache (`rss_seen.json`) to identify new ones.
+        5.  For each new entry (up to `limit`):
             *   Scrapes the content of the article linked in the entry.
             *   Uses a fast LLM (`FAST_LLM_MODEL`) to summarize the scraped article.
-        5.  Displays the summaries (title, publication date in your local time, link, summary) in Discord embeds. If the content is long, it's chunked into multiple embeds.
-        6.  Updates the `rss_seen.json` cache.
-        7.  Provides TTS for the combined summaries if enabled.
-        8.  The user's command and the bot's full summarized response are added to short-term history and ingested into ChromaDB.
-        9.  If no new entries are found, the bot replies with an ephemeral message instead of posting publicly.
+        6.  Displays the summaries (title, publication date in your local time, link, summary) in Discord embeds. If the content is long, it's chunked into multiple embeds.
+        7.  Updates the `rss_seen.json` cache.
+        8.  Provides TTS for the combined summaries if enabled.
+        9.  The user's command and the bot's full summarized response are added to short-term history and ingested into ChromaDB.
+        10.  If no new entries are found, the bot replies with an ephemeral message instead of posting publicly.
     *   **Output:** One or more embed messages containing summaries of new RSS feed entries, each showing the title, local publication date, link, and summary.
 
 *   **`/allrss [limit]`**

--- a/web_utils.py
+++ b/web_utils.py
@@ -4,6 +4,7 @@ import os
 import re
 import json
 from typing import List, Optional, Dict, Any, Callable, Awaitable, Tuple
+from urllib.parse import urlparse, parse_qs, unquote
 from bs4 import BeautifulSoup
 import random
 from datetime import datetime, timedelta, timezone
@@ -139,6 +140,20 @@ JS_EXTRACT_TWEETS_TWITTER = """
     return tweets;
 }
 """
+
+def resolve_google_redirect(url: str) -> str:
+    """Return the final target of a Google redirect URL if applicable."""
+    try:
+        parsed = urlparse(url)
+        if "google.com" not in parsed.netloc:
+            return url
+        qs = parse_qs(parsed.query)
+        for key in ("url", "q", "u"):
+            if key in qs and qs[key]:
+                return unquote(qs[key][0])
+    except Exception:
+        pass
+    return url
 
 async def _scrape_with_bs(url: str) -> Optional[str]:
     """Fallback scraping using aiohttp and BeautifulSoup with a Googlebot user agent."""
@@ -725,7 +740,7 @@ async def fetch_rss_entries(feed_url: str) -> List[Dict[str, Any]]:
             if pub_date_dt is None or pub_date_dt < one_days_ago:
                 continue
 
-            link_url = it.findtext("link") or ""
+            link_url = resolve_google_redirect(it.findtext("link") or "")
             if link_url.startswith("https://www.cbsnews.com/video/"):
                 continue
             if (


### PR DESCRIPTION
## Summary
- resolve Google redirect URLs when parsing RSS feeds
- document the change in RSS command behavior

## Testing
- `python -m py_compile web_utils.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68743752d53883288f0a42935657739e