### PR TITLE
Fix channel.send fallback

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -109,9 +109,11 @@ async def safe_followup_send(
                 "Interaction token expired%s; falling back to channel.send", " " + error_hint if error_hint else ""
             )
             if interaction.channel:
-                kwargs_no_ephemeral = dict(kwargs)
-                kwargs_no_ephemeral.pop("ephemeral", None)
-                return await interaction.channel.send(**kwargs_no_ephemeral)
+                kwargs_fallback = dict(kwargs)
+                # Remove parameters not supported by channel.send
+                kwargs_fallback.pop("ephemeral", None)
+                kwargs_fallback.pop("wait", None)
+                return await interaction.channel.send(**kwargs_fallback)
         raise
 
 


### PR DESCRIPTION
## Summary
- remove unsupported parameters when falling back to `channel.send`

## Testing
- `python -m py_compile utils.py`


------
https://chatgpt.com/codex/tasks/task_e_687595d0663c8328b51eddc395a3f1d8