### PR TITLE
Describe images in tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         *   `limit` (Optional, Default: 10): The maximum number of tweets to fetch (max 50).
     *   **Behavior:**
         1.  Uses `web_utils.scrape_latest_tweets` (Playwright with JS execution) to scrape recent tweets from the user's profile (specifically their "with_replies" timeline).
-        2.  Displays the raw fetched tweets (timestamp, author, content, link) in Discord embeds, chunked if necessary.
+        2.  Displays the raw fetched tweets (timestamp, author, content, link) in Discord embeds, chunked if necessary. Any images are downloaded and described via the vision LLM, and these descriptions are included with the tweet text.
         3.  Sends the text of these tweets to the LLM with a prompt to analyze and summarize the main themes, topics, and overall sentiment.
         4.  Streams this summary back to the Discord channel as a new message flow.
         5.  Provides TTS for the summary if enabled.
@@ -407,7 +407,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         *   `limit` (Optional, Default: 10): The maximum number of tweets to fetch (max 50).
     *   **Behavior:**
         1.  Uses `web_utils.scrape_home_timeline` (Playwright with JS execution) to scrape tweets from `https://x.com/home`.
-        2.  Displays the raw fetched tweets (timestamp, author, content, link) in Discord embeds, chunked if necessary.
+        2.  Displays the raw fetched tweets (timestamp, author, content, link) in Discord embeds, chunked if necessary. Any images are downloaded and described via the vision LLM, and these descriptions are included with the tweet text.
         3.  Sends the text of these tweets to the LLM with a prompt to analyze and summarize the main themes, topics, and overall sentiment.
         4.  Streams this summary back to the Discord channel as a new message flow.
         5.  Provides TTS for the summary if enabled.
@@ -423,7 +423,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
     *   **Behavior:**
         1.  Iterates through each preset Twitter account defined for the bot.
         2.  Uses `web_utils.scrape_latest_tweets` to scrape recent tweets for each account.
-        3.  Displays the raw fetched tweets in Discord embeds, chunked if necessary.
+        3.  Displays the raw fetched tweets in Discord embeds, chunked if necessary. Any images are downloaded and described via the vision LLM, and these descriptions are included with the tweet text.
         4.  Sends these tweets to the LLM to generate a brief summary, streamed back to the channel.
         5.  Provides TTS for each summary if enabled.
         6.  Stores newly fetched tweets in the `CHROMA_TWEETS_COLLECTION_NAME` collection for future retrieval.

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -427,11 +427,10 @@ async def process_twitter_user(
                     alt_text = t_data.alt_texts[i] if i < len(t_data.alt_texts) else None
                     if alt_text:
                         image_description_text += f'\n*Image Alt Text: "{alt_text}"*'
-                    else:
-                        await send_progress(f"Describing image in tweet from @{author_display}...")
-                        description = await describe_image(image_url)
-                        if description:
-                            image_description_text += f'\n*Image Description: "{description}"*'
+                    await send_progress(f"Describing image in tweet from @{author_display}...")
+                    description = await describe_image(image_url)
+                    if description:
+                        image_description_text += f'\n*Image Description: "{description}"*'
 
             link_text = f" ([Link]({tweet_url_display}))" if tweet_url_display else ""
             tweet_texts_for_display.append(f"**{header}**: {content_display}{image_description_text}{link_text}")
@@ -1496,11 +1495,10 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                         alt_text = t_data.alt_texts[i] if i < len(t_data.alt_texts) else None
                         if alt_text:
                             image_description_text += f'\n*Image Alt Text: "{alt_text}"*'
-                        else:
-                            await send_progress(f"Describing image in tweet from @{author_display}...")
-                            description = await describe_image(image_url)
-                            if description:
-                                image_description_text += f'\n*Image Description: "{description}"*'
+                        await send_progress(f"Describing image in tweet from @{author_display}...")
+                        description = await describe_image(image_url)
+                        if description:
+                            image_description_text += f'\n*Image Description: "{description}"*'
 
                 link_text = f" ([Link]({tweet_url_display}))" if tweet_url_display else ""
                 tweet_texts_for_display.append(f"**{header}**: {content_display}{image_description_text}{link_text}")
@@ -1762,11 +1760,10 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                         alt_text = t_data.alt_texts[i] if i < len(t_data.alt_texts) else None
                         if alt_text:
                             image_description_text += f'\n*Image Alt Text: "{alt_text}"*'
-                        else:
-                            await send_progress(f"Describing image in tweet from @{author_display}...")
-                            description = await describe_image(image_url)
-                            if description:
-                                image_description_text += f'\n*Image Description: "{description}"*'
+                        await send_progress(f"Describing image in tweet from @{author_display}...")
+                        description = await describe_image(image_url)
+                        if description:
+                            image_description_text += f'\n*Image Description: "{description}"*'
 
                 link_text = f" ([Link]({tweet_url_display}))" if tweet_url_display else ""
                 tweet_texts_for_display.append(f"**{header}**: {content_display}{image_description_text}{link_text}")


### PR DESCRIPTION
## Summary
- always send tweet images through the vision LLM for a description
- mention image descriptions in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68760761854c8328affc49ab0ba4ca0d