### PR TITLE
Improve Ground News scraping

### DIFF
--- a/web_utils.py
+++ b/web_utils.py
@@ -831,7 +831,17 @@ async def scrape_ground_news_my(limit: int = 10) -> List[GroundNewsArticle]:
                 page = await context_manager.new_page()
 
                 await page.goto("https://ground.news/my", wait_until="domcontentloaded")
-                await asyncio.sleep(5)
+                # Give the dynamic feed ample time to populate before we start scrolling
+                await asyncio.sleep(8)
+
+                # Scroll a few times to load additional articles
+                for _ in range(max(1, config.SCRAPE_SCROLL_ATTEMPTS)):
+                    try:
+                        await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+                    except Exception as e_scroll:
+                        logger.warning("Error scrolling Ground News page: %s", e_scroll)
+                        break
+                    await asyncio.sleep(3)
 
                 extracted = await page.evaluate(
                     """


### PR DESCRIPTION
## Summary
- add extra wait before interacting with Ground News feed
- scroll page before extracting article links so we capture more entries

## Testing
- `python -m py_compile web_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68775d5670188328916767dca151508c