### PR TITLE
Add Ground News scraping command

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,18 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         6.  Stores newly fetched tweets in the `CHROMA_TWEETS_COLLECTION_NAME` collection for future retrieval.
     *   **Output:** A series of embeds and summaries for each default account. If no new tweets are found for any account, the bot replies with an ephemeral message.
 
+*   **`/groundnews [limit]`**
+    *   **Purpose:** Scrapes the Ground News "My Feed" page and summarizes new articles.
+    *   **Arguments:**
+        *   `limit` (Optional, Default: 10): Maximum number of articles to process (max 20).
+    *   **Behavior:**
+        1.  Uses `web_utils.scrape_ground_news_my` (Playwright) to extract "See the Story" links, scrolling the page to load more items if necessary.
+        2.  Skips any links already recorded in `ground_news_seen.json`.
+        3.  Scrapes each new article with `web_utils.scrape_website` and summarizes it using the fast LLM.
+        4.  Displays the summaries (title, link, short summary) in Discord embeds and updates the cache.
+    *   **Requirements:** You must already be logged in to Ground News using Playwright's persistent profile (`.pw-profile`). If not logged in, the command will likely return no articles.
+    *   **Output:** Embeds containing summaries for each newly found Ground News article.
+
 *   **`/ap <image> [user_prompt]`**
     *   **Purpose:** Describes an attached image in the style of an Associated Press (AP) photo caption, with a humorous twist: a randomly chosen celebrity is creatively inserted as the main subject.
     *   **Arguments:**

--- a/common_models.py
+++ b/common_models.py
@@ -18,6 +18,14 @@ class TweetData:
     image_urls: List[str] = field(default_factory=list)
     alt_texts: List[Optional[str]] = field(default_factory=list)
 
+
+@dataclass
+class GroundNewsArticle:
+    """Represents an article entry from Ground News."""
+    title: str
+    url: str
+
+
 class MsgNode:
     """Represents a single message node in a conversation."""
     def __init__(self, role: str, content: Any, name: Optional[str] = None):

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -13,7 +13,7 @@ from email.utils import parsedate_to_datetime
 # Bot services and utilities
 from config import config
 from state import BotState
-from common_models import MsgNode, TweetData
+from common_models import MsgNode, TweetData, GroundNewsArticle
 
 from llm_handling import (
     _build_initial_prompt_messages,
@@ -34,6 +34,7 @@ from web_utils import (
     query_searx,
     scrape_latest_tweets,
     scrape_home_timeline,
+    scrape_ground_news_my,
     fetch_rss_entries
 )
 from audio_utils import send_tts_audio
@@ -45,6 +46,7 @@ from utils import (
 )
 from rss_cache import load_seen_entries, save_seen_entries
 from twitter_cache import load_seen_tweet_ids, save_seen_tweet_ids # New import
+from ground_news_cache import load_seen_links, save_seen_links
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +247,112 @@ async def process_rss_feed(
     await send_tts_audio(interaction, combined, base_filename=f"rss_{interaction.id}")
 
     user_msg = MsgNode("user", f"/rss {feed_url} (limit {limit})", name=str(interaction.user.id))
+    assistant_msg = MsgNode("assistant", combined, name=str(bot_instance.user.id))
+    await bot_state_instance.append_history(interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY)
+    await bot_state_instance.append_history(interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY)
+    await ingest_conversation_to_chromadb(
+        llm_client_instance,
+        interaction.channel_id,
+        interaction.user.id,
+        [user_msg, assistant_msg],
+        None,
+    )
+
+    return True
+
+
+async def process_ground_news(
+    interaction: discord.Interaction,
+    limit: int,
+) -> bool:
+    """Fetch and summarize new articles from Ground News 'My Feed'."""
+
+    progress_message = await safe_followup_send(
+        interaction,
+        content="Fetching Ground News articles...",
+    )
+
+    seen_urls = load_seen_links()
+
+    articles = await scrape_ground_news_my(limit)
+    new_articles = [a for a in articles if a.url not in seen_urls]
+
+    if not new_articles:
+        await safe_message_edit(
+            progress_message,
+            interaction.channel,
+            content="No new Ground News articles found.",
+        )
+        return False
+
+    summaries: List[str] = []
+    for idx, art in enumerate(new_articles[:limit], 1):
+        progress_message = await safe_message_edit(
+            progress_message,
+            interaction.channel,
+            content=f"Scraping {idx}/{len(new_articles[:limit])}: {art.title}...",
+        )
+
+        scraped_text, _ = await scrape_website(art.url)
+        if not scraped_text or "Failed to scrape" in scraped_text or "Scraping timed out" in scraped_text:
+            summaries.append(f"**{art.title}**\n{art.url}\nCould not scrape article\n")
+            seen_urls.add(art.url)
+            continue
+
+        prompt = (
+            "[It is currently 2025 and Donald Trump is the current president. Biden IS NOT THE CURRENT PRESIDENT! BIDEN IS THE EX PRESIDENT AND TRUMP IS THE PRESIDENT AGAIN FOR HIS SECOND TERM. THIS IS JUST KEY TEMPORAL KNOWLEDGE TO ORIENT YOU WHEN IT COMES UP. ANSWER ACCORDINGLY!] (Just an FYI. Maybe unrelated to context and omitted IF NOT RELATED TO TRUMP OR BIDEN OR THE YEAR. I NEED THE BEHAVIOR OF CALLING TRUMP THE EX-PRESIDENT AND CALLING THE CURRENT ADMINISTRATION THE BIDEN ADMINISTRATIONL. THESE ERRORS ARE UNACCEPTABLE. DON'T MENTION ME YELLING AT YOU. JUST DO THE DAMN THING!). "
+            "Do not use em dashes. Summarize the following article in 3-5 sentences. "
+            "Focus on key facts. Present in a casual, blunt, honest and slightly profane tone. Do NOT start with 'So, ' or end with 'Basically, '. Do not state things like 'This article describes', 'The article', etc. Present is as a person would if they were talking to you about the article.\n\n"
+            f"Title: {art.title}\nURL: {art.url}\n\n{scraped_text[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}"
+        )
+
+        try:
+            response = await llm_client_instance.chat.completions.create(
+                model=config.FAST_LLM_MODEL,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=500,
+                temperature=0.5,
+                stream=False,
+            )
+            summary = response.choices[0].message.content.strip() if response.choices else ""
+            if summary and summary != "[LLM summarization failed]":
+                store_rss_summary(
+                    feed_url="ground_news_my",
+                    article_url=art.url,
+                    title=art.title,
+                    summary_text=summary,
+                    timestamp=datetime.now(),
+                )
+        except Exception as e_summ:
+            logger.error("LLM summarization failed for %s: %s", art.url, e_summ)
+            summary = "[LLM summarization failed]"
+
+        summaries.append(f"**{art.title}**\n{art.url}\n{summary}\n")
+        seen_urls.add(art.url)
+
+    save_seen_links(seen_urls)
+
+    combined = "\n\n".join(summaries)
+    chunks = chunk_text(combined, config.EMBED_MAX_LENGTH)
+    for i, chunk in enumerate(chunks):
+        embed = discord.Embed(
+            title="Ground News Summaries" + ("" if i == 0 else f" (cont. {i+1})"),
+            description=chunk,
+            color=config.EMBED_COLOR["complete"],
+        )
+        if i == 0:
+            progress_message = await safe_message_edit(
+                progress_message,
+                interaction.channel,
+                content=None,
+                embed=embed,
+            )
+        else:
+            await safe_followup_send(interaction, embed=embed)
+
+    await send_tts_audio(interaction, combined, base_filename=f"groundnews_{interaction.id}")
+
+    user_msg = MsgNode("user", f"/groundnews (limit {limit})", name=str(interaction.user.id))
     assistant_msg = MsgNode("assistant", combined, name=str(bot_instance.user.id))
     await bot_state_instance.append_history(interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY)
     await bot_state_instance.append_history(interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY)
@@ -1960,6 +2068,56 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             if acquired_lock:
                 scrape_lock.release()
                 logger.debug("Scrape lock released for /alltweets")
+
+
+    @bot_instance.tree.command(name="groundnews", description="Scrapes Ground News 'My Feed' and summarizes new articles.")
+    @app_commands.describe(
+        limit="Number of articles to fetch (max 20)."
+    )
+    async def groundnews_slash_command(
+        interaction: discord.Interaction,
+        limit: app_commands.Range[int, 1, 20] = 10,
+    ) -> None:
+        if not llm_client_instance or not bot_state_instance or not bot_instance or not bot_instance.user:
+            logger.error("groundnews_slash_command: One or more bot components are None.")
+            await interaction.response.send_message("Bot components not ready. Cannot scrape Ground News.", ephemeral=True)
+            return
+
+        if interaction.channel_id is None:
+            await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
+            return
+
+        scrape_lock = bot_state_instance.get_scrape_lock()
+        queue_notice = scrape_lock.locked()
+        acquired_lock = False
+        if queue_notice:
+            await interaction.response.send_message(
+                "Waiting for other scraping tasks to finish before fetching Ground News...",
+                ephemeral=True,
+            )
+            await scrape_lock.acquire()
+            acquired_lock = True
+            await interaction.followup.send(content="Starting Ground News scraping...")
+        else:
+            await scrape_lock.acquire()
+            acquired_lock = True
+            await interaction.response.defer(ephemeral=False)
+
+        try:
+            processed = await process_ground_news(interaction, limit)
+            if not processed:
+                await safe_followup_send(
+                    interaction,
+                    content="No new Ground News articles found.",
+                    ephemeral=True,
+                )
+        except Exception as e:
+            logger.error("Error in groundnews_slash_command: %s", e, exc_info=True)
+            await interaction.followup.send(content=f"Failed to process Ground News articles. Error: {str(e)[:500]}")
+        finally:
+            if acquired_lock:
+                scrape_lock.release()
+                logger.debug("Scrape lock released for /groundnews")
 
 
     @bot_instance.tree.command(name="ap", description="Describes an attached image with a creative AP Photo twist.")

--- a/ground_news_cache.py
+++ b/ground_news_cache.py
@@ -1,0 +1,30 @@
+import json
+import os
+import logging
+from typing import Set
+
+logger = logging.getLogger(__name__)
+
+CACHE_FILE = os.path.join(os.path.dirname(__file__), "ground_news_seen.json")
+
+
+def load_seen_links() -> Set[str]:
+    """Load the set of previously processed Ground News article URLs."""
+    if os.path.exists(CACHE_FILE):
+        try:
+            with open(CACHE_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    return set(data)
+        except Exception as e:  # pragma: no cover - simple cache
+            logger.error("Failed to load Ground News cache from %s: %s", CACHE_FILE, e)
+    return set()
+
+
+def save_seen_links(urls: Set[str]) -> None:
+    """Persist the set of processed Ground News article URLs."""
+    try:
+        with open(CACHE_FILE, "w", encoding="utf-8") as f:
+            json.dump(list(urls), f)
+    except Exception as e:  # pragma: no cover - simple cache
+        logger.error("Failed to save Ground News cache to %s: %s", CACHE_FILE, e)

--- a/web_utils.py
+++ b/web_utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import json
-from typing import List, Optional, Dict, Any, Callable, Awaitable, Tuple
+from typing import List, Optional, Dict, Any, Callable, Awaitable, Tuple, Set
 from bs4 import BeautifulSoup
 import random
 from datetime import datetime, timedelta, timezone
@@ -18,7 +18,7 @@ import xml.etree.ElementTree
 # Assuming config is imported from config.py
 from config import config
 from utils import cleanup_playwright_processes
-from common_models import TweetData
+from common_models import TweetData, GroundNewsArticle
 
 logger = logging.getLogger(__name__)
 
@@ -775,3 +775,106 @@ async def fetch_rss_entries(feed_url: str) -> List[Dict[str, Any]]:
     except Exception as e:
         logger.error(f"Failed to parse RSS feed {feed_url}: {e}")
         return []
+
+
+async def scrape_ground_news_my(limit: int = 10) -> List[GroundNewsArticle]:
+    """Scrape the Ground News 'My Feed' page for article links.
+
+    Requires that the user is already logged in within the persistent
+    Playwright profile (``.pw-profile``). If not logged in, this function
+    will likely return an empty list.
+
+    Parameters
+    ----------
+    limit : int, optional
+        Maximum number of article links to return, by default ``10``.
+
+    Returns
+    -------
+    List[GroundNewsArticle]
+        Parsed article entries with title and URL.
+    """
+    logger.info("Scraping Ground News 'My Feed' for articles...")
+    articles: List[GroundNewsArticle] = []
+
+    user_data_dir = os.path.join(os.getcwd(), ".pw-profile")
+    profile_dir_usable = True
+    if not os.path.exists(user_data_dir):
+        try:
+            os.makedirs(user_data_dir, exist_ok=True)
+            logger.info("Created .pw-profile directory for Ground News scrape.")
+        except OSError as exc:
+            logger.error("Could not create .pw-profile directory: %s", exc)
+            profile_dir_usable = False
+
+    context_manager: Optional[Any] = None
+    browser_instance: Optional[Any] = None
+    page: Optional[Any] = None
+
+    try:
+        async with PLAYWRIGHT_SEM:
+            async with async_playwright() as p:
+                if profile_dir_usable:
+                    context = await p.chromium.launch_persistent_context(
+                        user_data_dir,
+                        headless=config.HEADLESS_PLAYWRIGHT,
+                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                        ignore_https_errors=True,
+                    )
+                else:
+                    browser_instance = await p.chromium.launch(
+                        headless=config.HEADLESS_PLAYWRIGHT,
+                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                    )
+                    context = await browser_instance.new_context(ignore_https_errors=True)
+                context_manager = context
+                page = await context_manager.new_page()
+
+                await page.goto("https://ground.news/my", wait_until="domcontentloaded")
+                await asyncio.sleep(5)
+
+                seen_urls: Set[str] = set()
+                scroll_attempt = 0
+                while len(articles) < limit and scroll_attempt <= config.SCRAPE_SCROLL_ATTEMPTS:
+                    extracted = await page.evaluate(
+                        """
+                        () => {
+                            const arts = [];
+                            document.querySelectorAll('article').forEach(a => {
+                                const link = Array.from(a.querySelectorAll('a')).find(el => el.textContent && el.textContent.includes('See the Story'));
+                                const titleEl = a.querySelector('h3, h2, h4');
+                                if (link) {
+                                    const title = titleEl ? titleEl.textContent.trim() : link.textContent.trim();
+                                    arts.push({title, url: link.href});
+                                }
+                            });
+                            return arts;
+                        }
+                        """
+                    )
+                    for item in extracted:
+                        if not isinstance(item, dict):
+                            continue
+                        title = str(item.get("title", "")).strip()
+                        url = str(item.get("url", "")).strip()
+                        if title and url and url not in seen_urls:
+                            seen_urls.add(url)
+                            articles.append(GroundNewsArticle(title=title, url=url))
+                            if len(articles) >= limit:
+                                break
+                    if len(articles) >= limit:
+                        break
+                    try:
+                        await page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+                        await asyncio.sleep(1.5)
+                    except Exception as e_scroll:
+                        logger.warning("Scrolling failed on Ground News page: %s", e_scroll)
+                        break
+                    scroll_attempt += 1
+    except Exception as e:
+        logger.error("Error scraping Ground News: %s", e, exc_info=True)
+    finally:
+        await _graceful_close_playwright(page, context_manager, browser_instance, profile_dir_usable)
+
+    logger.info("Found %s articles on Ground News", len(articles))
+    return articles


### PR DESCRIPTION
## Summary
- add `GroundNewsArticle` dataclass
- implement `scrape_ground_news_my` to collect articles from Ground News
- store previously processed links in `ground_news_seen.json`
- add `/groundnews` command to scrape and summarize new articles
- document `/groundnews` command in README
- fix the scraper to scroll for more articles and document login requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687759b9376083288450eda8685bedcc