### PR TITLE
Fix TTS max audio default

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `TTS_ENABLED_DEFAULT` (Default: `true`): Whether TTS is enabled by default for bot responses.
 *   `TTS_API_URL` (Default: `http://localhost:8880/v1/audio/speech`): The endpoint of your OpenAI TTS API compatible server.
 *   `TTS_VOICE` (Default: `af_sky+af+af_nicole`): The voice to be used for TTS generation. The format may depend on your TTS server.
-*   `TTS_MAX_AUDIO_BYTES` (Default: `26214400` (25MB)): Maximum size of a single generated TTS audio clip. Longer audio will be split into parts before uploading.
+*   `TTS_MAX_AUDIO_BYTES` (Default: `8388608` (8MB)): Maximum size of a single generated TTS audio clip. Longer audio will be split into parts before uploading to stay under Discord's attachment limits.
 
 **Web Features & Scraping:**
 

--- a/config.py
+++ b/config.py
@@ -72,7 +72,9 @@ class Config:
         self.TTS_API_URL = os.getenv("TTS_API_URL", "http://localhost:8880/v1/audio/speech")
         self.TTS_VOICE = os.getenv("TTS_VOICE", "af_sky+af+af_nicole")
         self.TTS_ENABLED_DEFAULT = _get_bool("TTS_ENABLED_DEFAULT", True)
-        self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 25 * 1024 * 1024)
+        # Discord limits attachments from bots to 8MB on most servers.
+        # Use 8MB as the default so TTS audio gets split automatically if needed.
+        self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)
 
         self.SEARX_URL = os.getenv("SEARX_URL", "http://192.168.1.3:9092/search")
         # Changed default for SEARX_PREFERENCES to an empty string.

--- a/example.env
+++ b/example.env
@@ -24,7 +24,7 @@ VISION_LLM_MODEL = gpt-4.1-nano-2025-04-14 # or for lmstudio: gemma-3-4b-it
 TTS_API_URL = http://localhost:8880/v1/audio/speech
 TTS_VOICE = af_sky+af+af_nicole
 TTS_ENABLED_DEFAULT = true # true or false
-TTS_MAX_AUDIO_BYTES = 26214400
+TTS_MAX_AUDIO_BYTES = 8388608
 
 CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
 


### PR DESCRIPTION
## Summary
- update default `TTS_MAX_AUDIO_BYTES` to 8 MB
- document new default in README
- change example `.env` accordingly

## Testing
- `python -m py_compile config.py audio_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687941993ab88328abe6e45ba50940f9