### PR TITLE
Fix cleanup script to clear references

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ DiscordSam is a modular Python application designed for extensibility and mainta
     *   **`common_models.py`**: Defines common data structures like `MsgNode` used throughout the application.
     *   **`rss_cache.py`**: Manages a local cache of seen RSS feed items to avoid reprocessing.
     *   **`timeline_pruner.py`**: Contains logic for the background task that prunes and summarizes old chat history from ChromaDB.
-    *   **`rag_cleanup.py`**: Utility script that removes distilled summary entries referencing conversation IDs that no longer exist in the main chat history collection.
+    *   **`rag_cleanup.py`**: Utility script that clears invalid conversation references in distilled summaries.
 
 **Data Flow Example (User sends a message mentioning the bot):**
 

--- a/rag_cleanup.py
+++ b/rag_cleanup.py
@@ -7,8 +7,14 @@ import rag_chroma_manager as rcm
 logger = logging.getLogger(__name__)
 
 
-def cleanup_distilled_entries(batch_size: int = 100, dry_run: bool = False) -> int:
-    """Remove distilled summary docs referencing missing conversations."""
+def clear_invalid_summary_refs(batch_size: int = 100, dry_run: bool = False) -> int:
+    """Clear invalid conversation references in distilled summaries.
+
+    Iterates over distilled summary documents and removes the
+    ``full_conversation_document_id`` metadata key when the
+    referenced conversation is missing. Returns the number of
+    references cleared.
+    """
     if not rcm.initialize_chromadb():
         logger.error("ChromaDB initialization failed")
         return 0
@@ -18,7 +24,7 @@ def cleanup_distilled_entries(batch_size: int = 100, dry_run: bool = False) -> i
         return 0
 
     total = rcm.distilled_chat_summary_collection.count()
-    removed = 0
+    cleared = 0
 
     for offset in range(0, total, batch_size):
         res = rcm.distilled_chat_summary_collection.get(
@@ -30,10 +36,13 @@ def cleanup_distilled_entries(batch_size: int = 100, dry_run: bool = False) -> i
         metas = res.get("metadatas", [])
 
         ids_to_check: Dict[str, str] = {}
+        metas_by_id: Dict[str, Dict] = {}
         invalid_ids: List[str] = []
 
         for i, doc_id in enumerate(ids):
             meta = metas[i] if i < len(metas) else {}
+            meta = meta or {}
+            metas_by_id[doc_id] = meta
             full_id = meta.get("full_conversation_document_id")
             if not full_id:
                 logger.info(
@@ -64,12 +73,23 @@ def cleanup_distilled_entries(batch_size: int = 100, dry_run: bool = False) -> i
 
         if invalid_ids:
             if dry_run:
-                logger.info("Would delete %d distilled docs: %s", len(invalid_ids), invalid_ids)
+                logger.info(
+                    "Would clear invalid references in %d docs: %s",
+                    len(invalid_ids),
+                    invalid_ids,
+                )
             else:
-                rcm.distilled_chat_summary_collection.delete(ids=invalid_ids)
-                removed += len(invalid_ids)
+                for doc_id in invalid_ids:
+                    meta = metas_by_id.get(doc_id, {}) or {}
+                    if "full_conversation_document_id" in meta:
+                        meta.pop("full_conversation_document_id", None)
+                    try:
+                        rcm.distilled_chat_summary_collection.update(ids=[doc_id], metadatas=[meta])
+                        cleared += 1
+                    except Exception as e_upd:
+                        logger.error("Failed updating metadata for %s: %s", doc_id, e_upd)
 
-    return removed
+    return cleared
 
 
 if __name__ == "__main__":
@@ -82,7 +102,7 @@ if __name__ == "__main__":
     )
 
     parser = argparse.ArgumentParser(
-        description="Remove distilled summary entries referencing missing chat history documents."
+        description="Clear invalid conversation references in distilled summaries."
     )
     parser.add_argument(
         "--dry-run",
@@ -97,10 +117,10 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    removed_count = cleanup_distilled_entries(batch_size=args.batch_size, dry_run=args.dry_run)
+    cleared_count = clear_invalid_summary_refs(batch_size=args.batch_size, dry_run=args.dry_run)
 
     if args.dry_run:
         logger.info("Dry run complete")
     else:
-        logger.info("Removed %d invalid distilled entries", removed_count)
+        logger.info("Cleared %d invalid conversation references", cleared_count)
 

--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -8,6 +8,7 @@ from openai import AsyncOpenAI
 
 from config import config
 import rag_chroma_manager as rcm
+import rag_cleanup
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +240,11 @@ async def prune_and_summarize(prune_days: int = PRUNE_DAYS):
 
         else:
             logger.warning(f"No summary generated for final block {block_start_dt.strftime('%Y-%m-%d %H:%M')} - {block_end_dt.strftime('%Y-%m-%d %H:%M')}; skipping deletion")
+
+    # Clear any invalid references in distilled summaries after pruning
+    cleared = rag_cleanup.clear_invalid_summary_refs()
+    if cleared:
+        logger.info(f"Cleared {cleared} invalid distilled summary references after pruning")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update `rag_cleanup.py` to clear missing conversation references instead of deleting documents
- log how many references are cleaned
- integrate cleanup into `timeline_pruner.prune_and_summarize`
- clarify README description of the cleanup script

## Testing
- `python -m py_compile rag_cleanup.py timeline_pruner.py`

------
https://chatgpt.com/codex/tasks/task_e_687bd7ea086c8328952d807bb8a44238