### PR TITLE
fix: Remove incorrect await on non-async function

### DIFF
--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -91,7 +91,7 @@ async def _get_collection_timestamps(collection) -> List[datetime]:
 
 
 async def print_collection_metrics() -> None:
-    if not await rcm.initialize_chromadb():
+    if not rcm.initialize_chromadb():
         logger.error("ChromaDB initialization failed")
         return
 
@@ -133,7 +133,7 @@ async def print_collection_metrics() -> None:
 
 
 async def prune_and_summarize(prune_days: int = PRUNE_DAYS):
-    if not await rcm.initialize_chromadb():
+    if not rcm.initialize_chromadb():
         logger.error("ChromaDB initialization failed")
         return
 


### PR DESCRIPTION
The `initialize_chromadb` function in `rag_chroma_manager.py` is a standard synchronous function, but it was being called with `await` in `timeline_pruner.py`. This caused a `TypeError` because you can't await a non-awaitable (a boolean in this case).

This commit removes the unnecessary `await` from the two call sites in `timeline_pruner.py`, resolving the runtime error in the timeline pruner task.