### PR TITLE
Integrate RAG cleanup with timeline pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ DiscordSam is a modular Python application designed for extensibility and mainta
     *   **`utils.py`**: Contains general helper functions like text chunking, URL detection, text cleaning for TTS, time string parsing, and Playwright process cleanup.
     *   **`common_models.py`**: Defines common data structures like `MsgNode` used throughout the application.
     *   **`rss_cache.py`**: Manages a local cache of seen RSS feed items to avoid reprocessing.
-    *   **`timeline_pruner.py`**: Contains logic for the background task that prunes and summarizes old chat history from ChromaDB.
-    *   **`rag_cleanup.py`**: Utility script that removes distilled summary entries referencing conversation IDs that no longer exist in the main chat history collection.
+    *   **`timeline_pruner.py`**: Contains logic for the background task that prunes and summarizes old chat history from ChromaDB. After each run it invokes `rag_cleanup` to remove stale references.
+    *   **`rag_cleanup.py`**: Cleans up distilled summaries by clearing references to conversation IDs that have been pruned from the main chat history.
 
 **Data Flow Example (User sends a message mentioning the bot):**
 

--- a/rag_cleanup.py
+++ b/rag_cleanup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import logging
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import rag_chroma_manager as rcm
 
@@ -8,7 +8,13 @@ logger = logging.getLogger(__name__)
 
 
 def cleanup_distilled_entries(batch_size: int = 100, dry_run: bool = False) -> int:
-    """Remove distilled summary docs referencing missing conversations."""
+    """Remove references to pruned conversations from distilled summaries.
+
+    Instead of deleting the distilled documents entirely, this function clears
+    the ``full_conversation_document_id`` metadata field when the referenced
+    conversation no longer exists. This preserves the distilled sentences while
+    ensuring stale references do not linger in the database.
+    """
     if not rcm.initialize_chromadb():
         logger.error("ChromaDB initialization failed")
         return 0
@@ -29,45 +35,63 @@ def cleanup_distilled_entries(batch_size: int = 100, dry_run: bool = False) -> i
         ids = res.get("ids", [])
         metas = res.get("metadatas", [])
 
-        ids_to_check: Dict[str, str] = {}
-        invalid_ids: List[str] = []
+        ids_to_check: Dict[str, Tuple[str, Dict]] = {}
+        invalid_docs: Dict[str, Dict] = {}
 
         for i, doc_id in enumerate(ids):
             meta = metas[i] if i < len(metas) else {}
             full_id = meta.get("full_conversation_document_id")
             if not full_id:
                 logger.info(
-                    "Distilled doc %s missing full_conversation_document_id", doc_id
+                    "Distilled doc %s missing full_conversation_document_id",
+                    doc_id,
                 )
-                invalid_ids.append(doc_id)
+                invalid_docs[doc_id] = meta
             else:
-                ids_to_check[doc_id] = str(full_id)
+                ids_to_check[doc_id] = (str(full_id), meta)
 
         if ids_to_check:
             try:
                 existence_res = rcm.chat_history_collection.get(
-                    ids=list(ids_to_check.values()),
+                    ids=[val[0] for val in ids_to_check.values()],
                     include=[],
                 )
                 existing = set(existence_res.get("ids", []))
             except Exception as e_get:
                 logger.error("Failed checking existence of chat history docs: %s", e_get)
                 existing = set()
-            for doc_id, full_id in ids_to_check.items():
+            for doc_id, (full_id, meta) in ids_to_check.items():
                 if full_id not in existing:
                     logger.info(
                         "Distilled doc %s references missing conversation %s",
                         doc_id,
                         full_id,
                     )
-                    invalid_ids.append(doc_id)
+                    invalid_docs[doc_id] = meta
 
-        if invalid_ids:
+        if invalid_docs:
             if dry_run:
-                logger.info("Would delete %d distilled docs: %s", len(invalid_ids), invalid_ids)
+                logger.info(
+                    "Would clear references for %d distilled docs: %s",
+                    len(invalid_docs),
+                    list(invalid_docs.keys()),
+                )
             else:
-                rcm.distilled_chat_summary_collection.delete(ids=invalid_ids)
-                removed += len(invalid_ids)
+                for doc_id, meta in invalid_docs.items():
+                    clean_meta = dict(meta)
+                    clean_meta.pop("full_conversation_document_id", None)
+                    try:
+                        rcm.distilled_chat_summary_collection.update(
+                            ids=doc_id,
+                            metadatas=clean_meta,
+                        )
+                        removed += 1
+                    except Exception as e_update:
+                        logger.error(
+                            "Failed updating metadata for distilled doc %s: %s",
+                            doc_id,
+                            e_update,
+                        )
 
     return removed
 
@@ -82,7 +106,7 @@ if __name__ == "__main__":
     )
 
     parser = argparse.ArgumentParser(
-        description="Remove distilled summary entries referencing missing chat history documents."
+        description="Clear references to missing chat history documents in distilled summaries."
     )
     parser.add_argument(
         "--dry-run",
@@ -97,10 +121,12 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    removed_count = cleanup_distilled_entries(batch_size=args.batch_size, dry_run=args.dry_run)
+    removed_count = cleanup_distilled_entries(
+        batch_size=args.batch_size, dry_run=args.dry_run
+    )
 
     if args.dry_run:
         logger.info("Dry run complete")
     else:
-        logger.info("Removed %d invalid distilled entries", removed_count)
+        logger.info("Cleared references from %d distilled entries", removed_count)
 

--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -8,6 +8,7 @@ from openai import AsyncOpenAI
 
 from config import config
 import rag_chroma_manager as rcm
+import rag_cleanup
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +240,10 @@ async def prune_and_summarize(prune_days: int = PRUNE_DAYS):
 
         else:
             logger.warning(f"No summary generated for final block {block_start_dt.strftime('%Y-%m-%d %H:%M')} - {block_end_dt.strftime('%Y-%m-%d %H:%M')}; skipping deletion")
+
+    # After pruning, remove stale references from distilled summaries
+    cleared = rag_cleanup.cleanup_distilled_entries()
+    logger.info("RAG cleanup cleared references from %d distilled entries", cleared)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep distilled sentences but strip missing convo references
- automatically run rag cleanup after pruning
- document the new cleanup behaviour in README

## Testing
- `python -m py_compile rag_cleanup.py timeline_pruner.py`
- `python rag_cleanup.py --dry-run --batch-size 1` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_687c0ffe98bc832890f95403ad26b2ec