### PR TITLE
Improve Ground News scraping reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `PLAYWRIGHT_MAX_CONCURRENCY` (Default: `2`): Maximum number of concurrent Playwright browser instances/contexts allowed.
 *   `SCRAPE_SCROLL_ATTEMPTS` (Default: `3`): How many times the bot will attempt to scroll down a webpage when scraping to load dynamically loaded content.
 *   `GROUND_NEWS_SEE_MORE_CLICKS` (Default: `3`): How many times to click Ground News's "See more stories" button before scraping.
+*   `GROUND_NEWS_CLICK_DELAY_SECONDS` (Default: `1.0`): Seconds to wait after each "See more stories" click when scraping Ground News.
 *   `PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES` (Default: `5`): How often the background task runs to check for and clean up idle Playwright processes.
 *   `PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES` (Default: `10`): How long Playwright must be idle (no scraping activity) before the cleanup task will terminate its processes.
 *   `SCRAPE_LOCK_TIMEOUT_SECONDS` (Default: `60`): How long to wait when acquiring the scraping lock before giving up.
@@ -435,7 +436,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
 *   **`/groundnews [limit]`**
     *   **Purpose:** Scrapes the Ground News "My Feed" page and summarizes new articles.
     *   **Arguments:**
-        *   `limit` (Optional, Default: 10): Maximum number of articles to process (max 20).
+        *   `limit` (Optional, Default: 10): Maximum number of articles to process (max 50).
     *   **Behavior:**
         1.  Uses `web_utils.scrape_ground_news_my` (Playwright) to extract "See the Story" links, scrolling the page to load more items if necessary.
         2.  Skips any links already recorded in `ground_news_seen.json`.

--- a/config.py
+++ b/config.py
@@ -135,6 +135,9 @@ class Config:
         self.PLAYWRIGHT_MAX_CONCURRENCY = _get_int("PLAYWRIGHT_MAX_CONCURRENCY", 2)
         self.SCRAPE_SCROLL_ATTEMPTS = _get_int("SCRAPE_SCROLL_ATTEMPTS", 3)
         self.GROUND_NEWS_SEE_MORE_CLICKS = _get_int("GROUND_NEWS_SEE_MORE_CLICKS", 3)
+        self.GROUND_NEWS_CLICK_DELAY_SECONDS = _get_float(
+            "GROUND_NEWS_CLICK_DELAY_SECONDS", 1.0
+        )
 
         # Configuration for Playwright cleanup task
         self.PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES = _get_int("PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES", 5) # How often the cleanup task runs

--- a/web_utils.py
+++ b/web_utils.py
@@ -78,28 +78,6 @@ JS_EXPAND_SHOWMORE_TWITTER = """
 }
 """
 
-JS_CLICK_SEE_MORE_GROUNDNEWS = """
-(maxClicks) => {
-    let clicks = 0;
-    function findButton() {
-        const byId = document.querySelector('#more-stories-my-feed');
-        if (byId) return byId;
-        return Array.from(document.querySelectorAll('button')).find(b =>
-            (b.textContent || '').toLowerCase().includes('see more stories'));
-    }
-    while (clicks < maxClicks) {
-        const btn = findButton();
-        if (!btn) break;
-        try {
-            btn.click();
-            clicks++;
-        } catch (e) {
-            break;
-        }
-    }
-    return clicks;
-}
-"""
 
 JS_EXTRACT_TWEETS_TWITTER = """
 () => {
@@ -860,21 +838,27 @@ async def scrape_ground_news_my(limit: int = 10) -> List[GroundNewsArticle]:
                 await page.goto("https://ground.news/my", wait_until="domcontentloaded")
                 await asyncio.sleep(5)
 
-                try:
-                    clicked = await page.evaluate(
-                        JS_CLICK_SEE_MORE_GROUNDNEWS,
-                        config.GROUND_NEWS_SEE_MORE_CLICKS,
-                    )
-                    if clicked:
-                        logger.info(
-                            "Clicked 'See more stories' button %s time(s) on Ground News",
-                            clicked,
+                clicks = 0
+                for _ in range(config.GROUND_NEWS_SEE_MORE_CLICKS):
+                    try:
+                        btn = await page.query_selector('#more-stories-my-feed')
+                        if not btn:
+                            btn = await page.query_selector("button:has-text('See more stories')")
+                        if not btn:
+                            break
+                        await btn.click()
+                        clicks += 1
+                        await asyncio.sleep(config.GROUND_NEWS_CLICK_DELAY_SECONDS)
+                    except Exception as e_click:
+                        logger.debug(
+                            "Error clicking 'See more stories' on Ground News: %s",
+                            e_click,
                         )
-                        await asyncio.sleep(2)
-                except Exception as e_click:
-                    logger.debug(
-                        "Error clicking 'See more stories' on Ground News: %s",
-                        e_click,
+                        break
+                if clicks:
+                    logger.info(
+                        "Clicked 'See more stories' button %s time(s) on Ground News",
+                        clicks,
                     )
 
                 seen_urls: Set[str] = set()


### PR DESCRIPTION
## Summary
- add configurable delay after clicking "See more stories"
- document new `GROUND_NEWS_CLICK_DELAY_SECONDS` option
- update max limit note for `/groundnews`
- remove unused JavaScript snippet and implement Python-based clicking loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c3c5b4d788328833fab799ed7c232