### PR TITLE
Make TTS speed configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `TTS_API_URL` (Default: `http://localhost:8880/v1/audio/speech`): The endpoint of your OpenAI TTS API compatible server.
 *   `TTS_VOICE` (Default: `af_sky+af+af_nicole`): The voice to be used for TTS generation. The format may depend on your TTS server.
 *   `TTS_MAX_AUDIO_BYTES` (Default: `8388608` (8MB)): Maximum size of a single generated TTS audio clip. Longer audio will be split into parts before uploading to stay under Discord's attachment limits.
+*   `TTS_SPEED` (Default: `1.3`): Playback speed multiplier for TTS audio. Use `1.0` for normal speed.
 
 **Web Features & Scraping:**
 

--- a/audio_utils.py
+++ b/audio_utils.py
@@ -34,14 +34,16 @@ def load_whisper_model() -> Optional[Any]:
             WHISPER_MODEL = None 
     return WHISPER_MODEL
 
-async def tts_request(text: str, speed: float = 1.3) -> Optional[bytes]:
+async def tts_request(text: str, speed: Optional[float] = None) -> Optional[bytes]:
     if not text:
         return None
+    if speed is None:
+        speed = config.TTS_SPEED
     payload = {
         "input": text,
         "voice": config.TTS_VOICE,
-        "response_format": "mp3", 
-        "speed": speed 
+        "response_format": "mp3",
+        "speed": speed,
     }
     try:
         async with aiohttp.ClientSession() as session:

--- a/config.py
+++ b/config.py
@@ -75,6 +75,7 @@ class Config:
         # Discord limits attachments from bots to 8MB on most servers.
         # Use 8MB as the default so TTS audio gets split automatically if needed.
         self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)
+        self.TTS_SPEED = _get_float("TTS_SPEED", 1.3)
 
         self.SEARX_URL = os.getenv("SEARX_URL", "http://192.168.1.3:9092/search")
         # Changed default for SEARX_PREFERENCES to an empty string.

--- a/example.env
+++ b/example.env
@@ -25,6 +25,7 @@ TTS_API_URL = http://localhost:8880/v1/audio/speech
 TTS_VOICE = af_sky+af+af_nicole
 TTS_ENABLED_DEFAULT = true # true or false
 TTS_MAX_AUDIO_BYTES = 8388608
+TTS_SPEED = 1.3
 
 CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
 


### PR DESCRIPTION
## Summary
- allow setting TTS speed via `TTS_SPEED` env variable
- default to config value in audio_utils
- document new variable in README and example.env

## Testing
- `python -m py_compile config.py audio_utils.py`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687c417ef1408328accb86f28d6f007a