### PR TITLE
feat: Implement exponential backoff for Ground News scraping

### DIFF
--- a/config.py
+++ b/config.py
@@ -139,6 +139,7 @@ class Config:
         self.GROUND_NEWS_CLICK_DELAY_SECONDS = _get_float(
             "GROUND_NEWS_CLICK_DELAY_SECONDS", 1.0
         )
+        self.GROUND_NEWS_MAX_RETRIES = _get_int("GROUND_NEWS_MAX_RETRIES", 3)
 
         # Configuration for Playwright cleanup task
         self.PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES = _get_int("PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES", 5) # How often the cleanup task runs

--- a/web_utils.py
+++ b/web_utils.py
@@ -833,7 +833,41 @@ async def _scrape_ground_news_page(page_url: str, limit: int = 10) -> List[Groun
                 context_manager = context
                 page = await context_manager.new_page()
 
-                await page.goto(page_url, wait_until="domcontentloaded")
+                response = None
+                for attempt in range(config.GROUND_NEWS_MAX_RETRIES + 1):
+                    try:
+                        response = await page.goto(page_url, wait_until="domcontentloaded", timeout=35000)
+                        if response and response.status != 403:
+                            logger.info("Successfully loaded Ground News page with status %s", response.status)
+                            break
+                        if response and response.status == 403:
+                            logger.warning(
+                                "Ground News returned 403 Forbidden. Attempt %s/%s.",
+                                attempt + 1,
+                                config.GROUND_NEWS_MAX_RETRIES,
+                            )
+                            if attempt < config.GROUND_NEWS_MAX_RETRIES:
+                                backoff_time = 2 ** (attempt + 1)
+                                logger.info("Waiting for %s seconds before retrying.", backoff_time)
+                                await asyncio.sleep(backoff_time)
+                            else:
+                                logger.error("Max retries reached for Ground News. Aborting scrape.")
+                                return []
+                        else:
+                            # If response is None or status is not 403, break and proceed
+                            logger.info("Page loaded without a 403 error.")
+                            break
+                    except PlaywrightTimeoutError:
+                        logger.error("Timeout loading Ground News page %s. Aborting.", page_url)
+                        return []
+                    except Exception as e_goto:
+                        logger.error("Error during page.goto for Ground News: %s", e_goto, exc_info=True)
+                        return []
+
+                if response and response.status == 403:
+                    logger.error("Failed to load Ground News page due to persistent 403 errors.")
+                    return []
+
                 await asyncio.sleep(5)
 
                 clicks = 0


### PR DESCRIPTION
Adds an exponential backoff mechanism to the Ground News scraper to handle 403 Forbidden errors. This prevents the scraper from being rate-limited when making too many requests in a short period.

A new configuration option, `GROUND_NEWS_MAX_RETRIES`, has been added to control the number of retries.