### PR TITLE
Add rate limiting to Ground News loops

### DIFF
--- a/discord_commands.py
+++ b/discord_commands.py
@@ -303,6 +303,9 @@ async def process_ground_news(
 
     summaries: List[str] = []
     for idx, art in enumerate(new_articles[:limit], 1):
+        if idx > 1:
+            # Rate limit scraping to ~3 pages per minute
+            await asyncio.sleep(20)
         progress_message = await safe_message_edit(
             progress_message,
             interaction.channel,
@@ -412,6 +415,9 @@ async def process_ground_news_topic(
 
     summaries: List[str] = []
     for idx, art in enumerate(new_articles[:limit], 1):
+        if idx > 1:
+            # Rate limit scraping to ~3 pages per minute
+            await asyncio.sleep(20)
         progress_message = await safe_message_edit(
             progress_message,
             interaction.channel,


### PR DESCRIPTION
## Summary
- add an `asyncio.sleep(20)` pause in Ground News scraping loops

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_687c940d53d4832898793f3435d684a0