### PR TITLE
Add configurable delay for Ground News article scrapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `SCRAPE_SCROLL_ATTEMPTS` (Default: `3`): How many times the bot will attempt to scroll down a webpage when scraping to load dynamically loaded content.
 *   `GROUND_NEWS_SEE_MORE_CLICKS` (Default: `3`): How many times to click Ground News's "See more stories" button before scraping.
 *   `GROUND_NEWS_CLICK_DELAY_SECONDS` (Default: `1.0`): Seconds to wait after each "See more stories" click when scraping Ground News.
+*   `GROUND_NEWS_ARTICLE_DELAY_SECONDS` (Default: `5.0`): Seconds to wait between scraping each Ground News article.
 *   `PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES` (Default: `5`): How often the background task runs to check for and clean up idle Playwright processes.
 *   `PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES` (Default: `10`): How long Playwright must be idle (no scraping activity) before the cleanup task will terminate its processes.
 *   `SCRAPE_LOCK_TIMEOUT_SECONDS` (Default: `60`): How long to wait when acquiring the scraping lock before giving up.

--- a/config.py
+++ b/config.py
@@ -139,6 +139,9 @@ class Config:
         self.GROUND_NEWS_CLICK_DELAY_SECONDS = _get_float(
             "GROUND_NEWS_CLICK_DELAY_SECONDS", 1.0
         )
+        self.GROUND_NEWS_ARTICLE_DELAY_SECONDS = _get_float(
+            "GROUND_NEWS_ARTICLE_DELAY_SECONDS", 5.0
+        )
 
         # Configuration for Playwright cleanup task
         self.PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES = _get_int("PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES", 5) # How often the cleanup task runs

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -305,7 +305,7 @@ async def process_ground_news(
     for idx, art in enumerate(new_articles[:limit], 1):
         if idx > 1:
             # Rate limit scraping
-            await asyncio.sleep(5)
+            await asyncio.sleep(config.GROUND_NEWS_ARTICLE_DELAY_SECONDS)
         progress_message = await safe_message_edit(
             progress_message,
             interaction.channel,
@@ -417,7 +417,7 @@ async def process_ground_news_topic(
     for idx, art in enumerate(new_articles[:limit], 1):
         if idx > 1:
             # Rate limit scraping
-            await asyncio.sleep(5)
+            await asyncio.sleep(config.GROUND_NEWS_ARTICLE_DELAY_SECONDS)
         progress_message = await safe_message_edit(
             progress_message,
             interaction.channel,

--- a/web_utils.py
+++ b/web_utils.py
@@ -834,7 +834,7 @@ async def _scrape_ground_news_page(page_url: str, limit: int = 10) -> List[Groun
                 page = await context_manager.new_page()
 
                 await page.goto(page_url, wait_until="domcontentloaded")
-                await asyncio.sleep(5)
+                await asyncio.sleep(config.GROUND_NEWS_ARTICLE_DELAY_SECONDS)
 
                 clicks = 0
                 selectors = [


### PR DESCRIPTION
## Summary
- add `GROUND_NEWS_ARTICLE_DELAY_SECONDS` setting
- document new setting in README
- use the new delay when opening Ground News pages and scraping each article

## Testing
- `python -m py_compile config.py discord_commands.py web_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_687ca7c2ec5c83288ea29173d9b3bdd4