### PR TITLE
Improve JSON handling in RAG module

### DIFF
--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -27,6 +27,31 @@ relation_collection: Optional[chromadb.Collection] = None
 observation_collection: Optional[chromadb.Collection] = None
 tweets_collection: Optional[chromadb.Collection] = None # New collection for tweets
 
+
+def _parse_json_with_recovery(content: str) -> Optional[Dict[str, Any]]:
+    """Load JSON, attempting to salvage truncated or noisy content."""
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            f"Initial JSON parse failed: {exc}; attempting recovery."
+        )
+
+        match = re.search(r"{.*}", content, re.DOTALL)
+        if match:
+            trimmed = match.group(0)
+            open_braces = trimmed.count("{")
+            close_braces = trimmed.count("}")
+            if open_braces > close_braces:
+                trimmed += "}" * (open_braces - close_braces)
+            try:
+                return json.loads(trimmed)
+            except json.JSONDecodeError as exc2:
+                logger.error(f"Trimmed JSON parse failed: {exc2}")
+
+        return None
+
+
 def initialize_chromadb() -> bool:
     global chroma_client, chat_history_collection, distilled_chat_summary_collection, \
            news_summary_collection, rss_summary_collection, timeline_summary_collection, entity_collection, \
@@ -190,27 +215,25 @@ Do not include any explanations or conversational text outside the JSON object.
                     raw_content = raw_content[:-3]
                 raw_content = raw_content.strip()
 
-            try:
-                extracted_data = json.loads(raw_content)
-                if not isinstance(extracted_data, dict) or \
-                   not all(key in extracted_data for key in ["entities", "relations", "observations"]) or \
-                   not isinstance(extracted_data["entities"], list) or \
-                   not isinstance(extracted_data["relations"], list) or \
-                   not isinstance(extracted_data["observations"], list):
-                    logger.warning(f"extract_structured_data_llm: LLM response for {source_doc_id} was not the expected dict structure. Content: {raw_content[:500]}")
-                    return None
-
-                logger.info(f"Successfully extracted structured data for {source_doc_id}: "
-                            f"{len(extracted_data['entities'])} entities, "
-                            f"{len(extracted_data['relations'])} relations, "
-                            f"{len(extracted_data['observations'])} observations.")
-                return extracted_data
-            except json.JSONDecodeError as json_e:
-                logger.error(f"extract_structured_data_llm: Failed to decode JSON from LLM response for {source_doc_id}. Error: {json_e}. Content: {raw_content[:500]}", exc_info=True)
+            extracted_data = _parse_json_with_recovery(raw_content)
+            if extracted_data is None:
+                logger.error(f"extract_structured_data_llm: Failed to decode JSON from LLM response for {source_doc_id}. Content: {raw_content[:500]}")
                 return None
-        else:
-            logger.warning(f"extract_structured_data_llm: LLM returned no content for {source_doc_id}.")
-            return None
+            if not isinstance(extracted_data, dict) or \
+               not all(key in extracted_data for key in ["entities", "relations", "observations"]) or \
+               not isinstance(extracted_data["entities"], list) or \
+               not isinstance(extracted_data["relations"], list) or \
+               not isinstance(extracted_data["observations"], list):
+                logger.warning(f"extract_structured_data_llm: LLM response for {source_doc_id} was not the expected dict structure. Content: {raw_content[:500]}")
+                return None
+
+            logger.info(
+                f"Successfully extracted structured data for {source_doc_id}: "
+                f"{len(extracted_data['entities'])} entities, "
+                f"{len(extracted_data['relations'])} relations, "
+                f"{len(extracted_data['observations'])} observations."
+            )
+            return extracted_data
     except Exception as e:
         if "response_format" in str(e) and response_format_arg:
             logger.warning(f"extract_structured_data_llm: Failed with response_format, retrying without it for {source_doc_id}. Error: {e}")
@@ -232,23 +255,26 @@ Do not include any explanations or conversational text outside the JSON object.
                         if raw_content.endswith("```"):
                             raw_content = raw_content[:-3]
                         raw_content = raw_content.strip()
-                    extracted_data = json.loads(raw_content) # type: ignore
-                    if not isinstance(extracted_data, dict) or \
+                    extracted_data = _parse_json_with_recovery(raw_content)
+                    if extracted_data is None:
+                        logger.error(f"extract_structured_data_llm (retry): Failed to decode JSON from LLM response for {source_doc_id}. Content: {raw_content[:500]}")
+                        return None
+                    if not isinstance(extracted_data, dict) or  \
                        not all(key in extracted_data for key in ["entities", "relations", "observations"]):
                         logger.warning(f"extract_structured_data_llm (retry): LLM response for {source_doc_id} was not the expected dict structure. Content: {raw_content[:500]}")
                         return None
                     logger.info(f"Successfully extracted structured data (on retry) for {source_doc_id}.")
-                    return extracted_data # type: ignore
+                    return extracted_data
                 else:
                     logger.warning(f"extract_structured_data_llm (retry): LLM returned no content for {source_doc_id}.")
                     return None
+
             except Exception as retry_e:
                 logger.error(f"extract_structured_data_llm: Failed on retry for {source_doc_id}: {retry_e}", exc_info=True)
                 return None
         else:
             logger.error(f"extract_structured_data_llm: Failed to extract data for {source_doc_id}: {e}", exc_info=True)
             return None
-
 
 async def distill_conversation_to_sentence_llm(llm_client: Any, text_to_distill: str) -> Optional[str]:
     if not text_to_distill.strip():


### PR DESCRIPTION
## Summary
- add more robust `_parse_json_with_recovery` to salvage truncated JSON
- ensure PEP 8 spacing between top-level functions

## Testing
- `python -m py_compile rag_chroma_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f340a9824832887687e6ce90f87d4