### PR TITLE
Add post-processing progress indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ DiscordSam is a modular Python application designed for extensibility and mainta
     *   `_build_initial_prompt_messages()`: Constructs the complete prompt (system message, RAG context, conversation history, user query) to be sent to the LLM.
     *   `stream_llm_response_to_interaction()` and `stream_llm_response_to_message()`: Manage the streaming of LLM responses back to Discord, updating messages in real-time.
     *   Handles post-response actions like updating conversation history in `BotState`, triggering TTS via `audio_utils`, and ingesting the conversation into ChromaDB via `rag_chroma_manager`.
+    *   Shows a short "Post-processing" notification while the conversation is being archived and analyzed.
     *   `get_description_for_image()`: Uses a vision-capable LLM to describe images.
 
 7.  **RAG and ChromaDB Management (`rag_chroma_manager.py`)**:

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -572,6 +572,14 @@ async def stream_llm_response_to_interaction(
         chroma_ingest_history_with_response.append(assistant_response_node)
 
     if assistant_response_node:
+        progress_msg = None
+        try:
+            progress_msg = await interaction.followup.send(
+                content="\U0001F501 Post-processing...", ephemeral=True
+            )
+        except discord.HTTPException:
+            progress_msg = None
+
         await ingest_conversation_to_chromadb(
             llm_client,
             channel_id,
@@ -579,6 +587,12 @@ async def stream_llm_response_to_interaction(
             chroma_ingest_history_with_response,
             retrieved_snippets,
         )
+
+        if progress_msg:
+            try:
+                await progress_msg.edit(content="Post-processing complete.")
+            except discord.HTTPException:
+                pass
 
 
 async def stream_llm_response_to_message(
@@ -652,6 +666,14 @@ async def stream_llm_response_to_message(
         chroma_ingest_history_with_response.append(assistant_response_node)
 
     if assistant_response_node:
+        post_msg = None
+        try:
+            post_msg = await target_message.reply(
+                "\U0001F501 Post-processing...", mention_author=False
+            )
+        except discord.HTTPException:
+            post_msg = None
+
         await ingest_conversation_to_chromadb(
             llm_client,
             channel_id,
@@ -659,6 +681,12 @@ async def stream_llm_response_to_message(
             chroma_ingest_history_with_response,
             retrieved_snippets,
         )
+
+        if post_msg:
+            try:
+                await post_msg.edit(content="Post-processing complete.")
+            except discord.HTTPException:
+                pass
 
 
 async def get_description_for_image(llm_client: Any, image_path: str) -> str:


### PR DESCRIPTION
## Summary
- show a temporary "Post-processing" notification while conversations are archived
- document the new progress indicator

## Testing
- `python -m py_compile llm_handling.py`

------
https://chatgpt.com/codex/tasks/task_e_68807f325bf4832898c323ac19b6c19f