### PR TITLE
Improve ephemeral post-processing notice

### DIFF
--- a/llm_handling.py
+++ b/llm_handling.py
@@ -590,7 +590,15 @@ async def stream_llm_response_to_interaction(
 
         if progress_msg:
             try:
-                await progress_msg.edit(content="Post-processing complete.")
+                await progress_msg.delete()
+            except discord.HTTPException:
+                pass
+            try:
+                await interaction.followup.send(
+                    content="Post-processing complete.",
+                    ephemeral=True,
+                    delete_after=10,
+                )
             except discord.HTTPException:
                 pass
 


### PR DESCRIPTION
## Summary
- replace the `Post-processing complete` edit with a new ephemeral follow-up

## Testing
- `python -m py_compile llm_handling.py`


------
https://chatgpt.com/codex/tasks/task_e_6880c4ef50188328824cfe9c39dd8d8c