### PR TITLE
Improve ephemeral post-processing notice

### DIFF
--- a/llm_handling.py
+++ b/llm_handling.py
@@ -590,7 +590,18 @@ async def stream_llm_response_to_interaction(
 
         if progress_msg:
             try:
-                await progress_msg.edit(content="Post-processing complete.")
+                await progress_msg.delete()
+            except discord.HTTPException:
+                pass
+            try:
+                done_msg = await interaction.followup.send(
+                    content="Post-processing complete.",
+                    ephemeral=True,
+                )
+                try:
+                    await done_msg.delete(delay=10)
+                except discord.HTTPException:
+                    pass
             except discord.HTTPException:
                 pass
 


### PR DESCRIPTION
## Summary
- replace ephemeral completion message's unsupported `delete_after`
- schedule deletion directly

## Testing
- `python -m py_compile llm_handling.py`


------
https://chatgpt.com/codex/tasks/task_e_6880c4ef50188328824cfe9c39dd8d8c