### PR TITLE
Improve ephemeral post-processing notice

### DIFF
--- a/llm_handling.py
+++ b/llm_handling.py
@@ -591,6 +591,7 @@ async def stream_llm_response_to_interaction(
         if progress_msg:
             try:
                 await progress_msg.edit(content="Post-processing complete.")
+                await progress_msg.delete(delay=10)
             except discord.HTTPException:
                 pass
 


### PR DESCRIPTION
## Summary
- edit progress message to show "Post-processing complete" then delete it

## Testing
- `python -m py_compile llm_handling.py`


------
https://chatgpt.com/codex/tasks/task_e_6880c4ef50188328824cfe9c39dd8d8c