### PR TITLE
Improve ephemeral post-processing notice

### DIFF
--- a/llm_handling.py
+++ b/llm_handling.py
@@ -590,9 +590,18 @@ async def stream_llm_response_to_interaction(
 
         if progress_msg:
             try:
-                await progress_msg.edit(content="Post-processing complete.")
+                await progress_msg.delete()
             except discord.HTTPException:
                 pass
+
+        try:
+            await interaction.followup.send(
+                content="Post-processing complete.",
+                ephemeral=True,
+                delete_after=10,
+            )
+        except discord.HTTPException:
+            pass
 
 
 async def stream_llm_response_to_message(
@@ -685,6 +694,7 @@ async def stream_llm_response_to_message(
         if post_msg:
             try:
                 await post_msg.edit(content="Post-processing complete.")
+                await post_msg.delete(delay=10)
             except discord.HTTPException:
                 pass
 


### PR DESCRIPTION
## Summary
- delete the progress message after background tasks finish
- send a new ephemeral message confirming completion that disappears after 10s
- clean up follow-up message in message reply workflow

## Testing
- `python -m py_compile llm_handling.py`


------
https://chatgpt.com/codex/tasks/task_e_6880c4ef50188328824cfe9c39dd8d8c