### PR TITLE
Standardize post-processing completion handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ DiscordSam is a modular Python application designed for extensibility and mainta
     *   `_build_initial_prompt_messages()`: Constructs the complete prompt (system message, RAG context, conversation history, user query) to be sent to the LLM.
     *   `stream_llm_response_to_interaction()` and `stream_llm_response_to_message()`: Manage the streaming of LLM responses back to Discord, updating messages in real-time.
     *   Handles post-response actions like updating conversation history in `BotState`, triggering TTS via `audio_utils`, and ingesting the conversation into ChromaDB via `rag_chroma_manager`.
-    *   Shows a short "Post-processing" notification while the conversation is being archived and analyzed.
+    *   Shows a short "Post-processing" notification while the conversation is being archived and analyzed. Once complete, the progress message is removed and the user receives an ephemeral "Post-processing complete" notice (via DM for regular messages).
     *   `get_description_for_image()`: Uses a vision-capable LLM to describe images.
 
 7.  **RAG and ChromaDB Management (`rag_chroma_manager.py`)**:

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -692,8 +692,12 @@ async def stream_llm_response_to_message(
 
         if post_msg:
             try:
-                await post_msg.edit(content="Post-processing complete.")
-                await post_msg.delete(delay=10)
+                await post_msg.delete()
+            except discord.HTTPException:
+                pass
+
+            try:
+                await target_message.author.send("Post-processing complete.")
             except discord.HTTPException:
                 pass
 


### PR DESCRIPTION
## Summary
- update docs about post-processing completion message
- modify `stream_llm_response_to_message` to delete the progress message and DM the user a completion notice

## Testing
- `python -m py_compile llm_handling.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6880da482abc8328868bcf13344ab9a5