### PR TITLE
Add config to ignore <think> sections in TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `TTS_VOICE` (Default: `af_sky+af+af_nicole`): The voice to be used for TTS generation. The format may depend on your TTS server.
 *   `TTS_MAX_AUDIO_BYTES` (Default: `8388608` (8MB)): Maximum size of a single generated TTS audio clip. Longer audio will be split into parts before uploading to stay under Discord's attachment limits.
 *   `TTS_SPEED` (Default: `1.3`): Playback speed multiplier for TTS audio. Use `1.0` for normal speed.
+*   `TTS_INCLUDE_THOUGHTS` (Default: `false`): If `true`, content within `<think>...</think>` tags will also be spoken using TTS. When `false`, only the user-facing portion of the response is processed.
 
 **Web Features & Scraping:**
 

--- a/config.py
+++ b/config.py
@@ -72,6 +72,7 @@ class Config:
         self.TTS_API_URL = os.getenv("TTS_API_URL", "http://localhost:8880/v1/audio/speech")
         self.TTS_VOICE = os.getenv("TTS_VOICE", "af_sky+af+af_nicole")
         self.TTS_ENABLED_DEFAULT = _get_bool("TTS_ENABLED_DEFAULT", True)
+        self.TTS_INCLUDE_THOUGHTS = _get_bool("TTS_INCLUDE_THOUGHTS", False)
         # Discord limits attachments from bots to 8MB on most servers.
         # Use 8MB as the default so TTS audio gets split automatically if needed.
         self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)

--- a/example.env
+++ b/example.env
@@ -26,6 +26,7 @@ TTS_VOICE = af_sky+af+af_nicole
 TTS_ENABLED_DEFAULT = true # true or false
 TTS_MAX_AUDIO_BYTES = 8388608
 TTS_SPEED = 1.3
+TTS_INCLUDE_THOUGHTS = false
 
 CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
 


### PR DESCRIPTION
## Summary
- add `TTS_INCLUDE_THOUGHTS` option to config
- ignore `<think>` sections in `send_tts_audio` unless enabled
- document new setting in README and example.env

## Testing
- `python -m py_compile config.py audio_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a1e891cc832891d6417ce31cd67d