### PR TITLE
Limit RAG ingestion to final exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ DiscordSam is a modular Python application designed for extensibility and mainta
 7.  After the stream:
     *   The user's message and the bot's full response are added to `BotState.message_history`.
     *   `audio_utils.send_tts_audio` is called (as a background task) if TTS is enabled.
-    *   `rag_chroma_manager.ingest_conversation_to_chromadb` stores the exchange, extracts structured data, and distills key sentences into ChromaDB.
+    *   `rag_chroma_manager.ingest_conversation_to_chromadb` stores **only** this final user question and bot answer (not the full prompt) and distills it for RAG.
 
 This modular architecture allows for easier development, testing, and modification of individual components without impacting the entire system.
 
@@ -221,7 +221,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 **ChromaDB (RAG & Long-Term Memory):**
 
 *   `CHROMA_DB_PATH` (Default: `./chroma_data`): The local file system path where ChromaDB will store its data.
-*   `CHROMA_COLLECTION_NAME` (Default: `long_term_memory`): Name of the ChromaDB collection for storing full conversation logs.
+*   `CHROMA_COLLECTION_NAME` (Default: `long_term_memory`): Name of the ChromaDB collection for storing recent conversation exchanges (user prompt and bot response).
 *   `CHROMA_DISTILLED_COLLECTION_NAME` (Default: `distilled_chat_summaries`): Name of the collection for storing concise, keyword-rich distilled summaries of conversations (used for primary RAG retrieval).
 *   `CHROMA_NEWS_SUMMARY_COLLECTION_NAME` (Default: `news_summaries`): Collection for storing summaries of news articles processed by the `/news` command.
 *   `CHROMA_RSS_SUMMARY_COLLECTION_NAME` (Default: `rss_summaries`): Collection for storing summaries of RSS feed items processed by the `/rss` command.

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -532,8 +532,11 @@ async def stream_llm_response_to_interaction(
                 interaction, full_response_content, f"interaction_{tts_base_id}"
             )
 
-            chroma_ingest_history_with_response = list(final_prompt_for_rag)
-            chroma_ingest_history_with_response.append(assistant_response_node)
+            # Only store the actual user question and final response for RAG
+            chroma_ingest_history_with_response = [
+                user_msg_node,
+                assistant_response_node,
+            ]
     else:
         full_response_content, final_prompt_for_rag = await _run_stream()
 
@@ -568,8 +571,11 @@ async def stream_llm_response_to_interaction(
 
         await send_tts_audio(interaction, full_response_content, f"interaction_{tts_base_id}")
 
-        chroma_ingest_history_with_response = list(final_prompt_for_rag)
-        chroma_ingest_history_with_response.append(assistant_response_node)
+        # Only store the visible exchange (user question + assistant response)
+        chroma_ingest_history_with_response = [
+            user_msg_node,
+            assistant_response_node,
+        ]
 
     if assistant_response_node:
         progress_msg = None
@@ -670,8 +676,11 @@ async def stream_llm_response_to_message(
             base_filename=f"message_{target_message.id}",
         )
 
-        chroma_ingest_history_with_response = list(final_prompt_for_rag)
-        chroma_ingest_history_with_response.append(assistant_response_node)
+        # Persist only the final visible exchange
+        chroma_ingest_history_with_response = [
+            user_msg_node,
+            assistant_response_node,
+        ]
 
     if assistant_response_node:
         post_msg = None


### PR DESCRIPTION
## Summary
- store only the visible user question and final response when archiving conversations
- document new ingestion behavior in README

## Testing
- `python -m py_compile llm_handling.py`
- `flake8 llm_handling.py` *(fails: many existing style violations)*

------
https://chatgpt.com/codex/tasks/task_e_688354c76a088328984a623477cbc531