### PR TITLE
Ingest Ground News summaries individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         2.  Skips any links already recorded in `ground_news_seen.json`.
         3.  Scrapes each new article with `web_utils.scrape_website` and summarizes it using the fast LLM.
         4.  Displays the summaries (title, link, short summary) in Discord embeds and updates the cache.
+        5.  Each article summary is ingested into ChromaDB individually as it is processed.
     *   **Requirements:** You must already be logged in to Ground News using Playwright's persistent profile (`.pw-profile`). If not logged in, the command will likely return no articles.
     *   **Output:** Embeds containing summaries for each newly found Ground News article.
 
@@ -460,6 +461,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         2.  Skips links already recorded in `ground_news_seen.json`.
         3.  Scrapes and summarizes each new article via the fast LLM.
         4.  Displays summaries in Discord embeds and updates the cache.
+        5.  Each article summary is ingested into ChromaDB individually as it is processed.
     *   **Requirements:** Same as `/groundnews` &mdash; you must be logged in with Playwright's persistent profile.
     *   **Output:** Embeds containing summaries for each new topic article.
 

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -346,8 +346,35 @@ async def process_ground_news(
             logger.error("LLM summarization failed for %s: %s", art.url, e_summ)
             summary = "[LLM summarization failed]"
 
-        summaries.append(f"**{art.title}**\n{art.url}\n{summary}\n")
+        summary_line = f"**{art.title}**\n{art.url}\n{summary}\n"
+        summaries.append(summary_line)
         seen_urls.add(art.url)
+
+        user_msg_article = MsgNode(
+            "user",
+            f"/groundnews article {idx} (limit {limit})",
+            name=str(interaction.user.id),
+        )
+        assistant_msg_article = MsgNode(
+            "assistant",
+            summary_line,
+            name=str(bot_instance.user.id),
+        )
+        await bot_state_instance.append_history(
+            interaction.channel_id, user_msg_article, config.MAX_MESSAGE_HISTORY
+        )
+        await bot_state_instance.append_history(
+            interaction.channel_id,
+            assistant_msg_article,
+            config.MAX_MESSAGE_HISTORY,
+        )
+        await ingest_conversation_to_chromadb(
+            llm_client_instance,
+            interaction.channel_id,
+            interaction.user.id,
+            [user_msg_article, assistant_msg_article],
+            None,
+        )
 
     save_seen_links(seen_urls)
 
@@ -371,17 +398,7 @@ async def process_ground_news(
 
     await send_tts_audio(interaction, combined, base_filename=f"groundnews_{interaction.id}")
 
-    user_msg = MsgNode("user", f"/groundnews (limit {limit})", name=str(interaction.user.id))
-    assistant_msg = MsgNode("assistant", combined, name=str(bot_instance.user.id))
-    await bot_state_instance.append_history(interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY)
-    await bot_state_instance.append_history(interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY)
-    await ingest_conversation_to_chromadb(
-        llm_client_instance,
-        interaction.channel_id,
-        interaction.user.id,
-        [user_msg, assistant_msg],
-        None,
-    )
+
 
     return True
 
@@ -458,8 +475,35 @@ async def process_ground_news_topic(
             logger.error("LLM summarization failed for %s: %s", art.url, e_summ)
             summary = "[LLM summarization failed]"
 
-        summaries.append(f"**{art.title}**\n{art.url}\n{summary}\n")
+        summary_line = f"**{art.title}**\n{art.url}\n{summary}\n"
+        summaries.append(summary_line)
         seen_urls.add(art.url)
+
+        user_msg_article = MsgNode(
+            "user",
+            f"/groundtopic {topic_slug} article {idx} (limit {limit})",
+            name=str(interaction.user.id),
+        )
+        assistant_msg_article = MsgNode(
+            "assistant",
+            summary_line,
+            name=str(bot_instance.user.id),
+        )
+        await bot_state_instance.append_history(
+            interaction.channel_id, user_msg_article, config.MAX_MESSAGE_HISTORY
+        )
+        await bot_state_instance.append_history(
+            interaction.channel_id,
+            assistant_msg_article,
+            config.MAX_MESSAGE_HISTORY,
+        )
+        await ingest_conversation_to_chromadb(
+            llm_client_instance,
+            interaction.channel_id,
+            interaction.user.id,
+            [user_msg_article, assistant_msg_article],
+            None,
+        )
 
     save_seen_links(seen_urls)
 
@@ -482,18 +526,6 @@ async def process_ground_news_topic(
             await safe_followup_send(interaction, embed=embed)
 
     await send_tts_audio(interaction, combined, base_filename=f"groundtopic_{interaction.id}")
-
-    user_msg = MsgNode("user", f"/groundtopic {topic_slug} (limit {limit})", name=str(interaction.user.id))
-    assistant_msg = MsgNode("assistant", combined, name=str(bot_instance.user.id))
-    await bot_state_instance.append_history(interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY)
-    await bot_state_instance.append_history(interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY)
-    await ingest_conversation_to_chromadb(
-        llm_client_instance,
-        interaction.channel_id,
-        interaction.user.id,
-        [user_msg, assistant_msg],
-        None,
-    )
 
     return True
 


### PR DESCRIPTION
## Summary
- ingest each Ground News article as it is processed
- drop final bulk ingestion for the two ground news commands
- document the per-article ingestion behavior in the README

## Testing
- `python -m py_compile discord_commands.py ground_news_cache.py web_utils.py llm_handling.py rag_chroma_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68844f8da6ac83289f4bd7ac0326c402