### PR TITLE
Make post-processing async

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ DiscordSam is a modular Python application designed for extensibility and mainta
     *   `get_system_prompt()`: Loads the bot's persona and instructions.
     *   `_build_initial_prompt_messages()`: Constructs the complete prompt (system message, RAG context, conversation history, user query) to be sent to the LLM.
     *   `stream_llm_response_to_interaction()` and `stream_llm_response_to_message()`: Manage the streaming of LLM responses back to Discord, updating messages in real-time.
-    *   Handles post-response actions like updating conversation history in `BotState`, triggering TTS via `audio_utils`, and ingesting the conversation into ChromaDB via `rag_chroma_manager`.
-    *   Shows a short "Post-processing" notification while conversations and other ingestion tasks (e.g., RSS or Ground News summaries) are archived and analyzed. Once complete, the progress message is removed and the user receives an ephemeral "Post-processing complete" notice (via DM for regular messages).
+    *   Handles post-response actions like updating conversation history in `BotState`, triggering TTS via `audio_utils`, and **asynchronously** ingesting the conversation into ChromaDB via `rag_chroma_manager`.
+    *   Shows a short "Post-processing" notification while conversations and other ingestion tasks are archived and analyzed. These tasks now run in the background so replies are never blocked. Once finished, the progress message is removed and the user receives an ephemeral "Post-processing complete" notice (via DM for regular messages).
     *   `get_description_for_image()`: Uses a vision-capable LLM to describe images.
 
 7.  **RAG and ChromaDB Management (`rag_chroma_manager.py`)**:

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
+import asyncio
 import re
 from datetime import timedelta
-from typing import List, Optional, Tuple, Any
+from typing import List, Optional, Tuple, Any, Coroutine
 import psutil
 import logging
 import discord
@@ -161,3 +162,44 @@ async def safe_message_edit(
                     pass
             return new_msg
         raise
+
+
+def start_post_processing_task(
+    coro: Coroutine[Any, Any, Any],
+    *,
+    progress_message: Optional[discord.Message] = None,
+    followup_interaction: Optional[discord.Interaction] = None,
+) -> asyncio.Task:
+    """Run ``coro`` in the background and handle progress cleanup.
+
+    Parameters
+    ----------
+    coro:
+        The coroutine performing the post-processing work.
+    progress_message:
+        Optional message indicating progress. It will be deleted when
+        ``coro`` finishes.
+    followup_interaction:
+        If provided, an ephemeral "Post-processing complete" message will
+        be sent via ``interaction.followup`` when done.
+    """
+
+    async def _runner() -> None:
+        try:
+            await coro
+        finally:
+            if progress_message:
+                try:
+                    await progress_message.delete()
+                except discord.HTTPException:
+                    pass
+            if followup_interaction:
+                try:
+                    await followup_interaction.followup.send(
+                        content="Post-processing complete.",
+                        ephemeral=True,
+                    )
+                except discord.HTTPException:
+                    pass
+
+    return asyncio.create_task(_runner())


### PR DESCRIPTION
## Summary
- schedule DB ingestion via `start_post_processing_task`
- use the new helper in `llm_handling` and `discord_commands`
- mention asynchronous post-processing in the docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b232479908328abb8a71de69d1d8a