### PR TITLE
Fix ground news post-processing spam

### DIFF
--- a/discord_commands.py
+++ b/discord_commands.py
@@ -408,7 +408,6 @@ async def process_ground_news(
                 None,
             ),
             progress_message=progress_ephemeral,
-            followup_interaction=interaction,
         )
 
     save_seen_links(seen_urls)
@@ -559,7 +558,6 @@ async def process_ground_news_topic(
                 None,
             ),
             progress_message=progress_ephemeral,
-            followup_interaction=interaction,
         )
 
     save_seen_links(seen_urls)


### PR DESCRIPTION
## Summary
- remove `followup_interaction` for each Ground News article ingestion

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_688b332e13e483288dc553596d9c2226