### PR TITLE
Add InvokeAI image generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
 *   **Multimedia Interaction:**
     *   Analyze and describe attached images (with a creative "AP Photo" twist using a vision LLM).
     *   Transcribe attached audio files using a local Whisper model.
+    *   Generate images using a local InvokeAI server.
 *   **Text-to-Speech (TTS):**
     *   Voice responses for bot messages via an OpenAI TTS API compatible server.
     *   Separate TTS for "thoughts" (content within `<think>...</think>` tags) vs. main response if configured.
@@ -253,6 +254,11 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 **Image Processing (Attachments & Vision):**
 
 *   `MAX_IMAGES_PER_MESSAGE` (Default: `1`): The maximum number of images attached to a single Discord message that the bot will process and send to the vision LLM.
+
+**Image Generation (InvokeAI):**
+
+*   `INVOKEAI_API_URL` (Default: `http://localhost:9090`): Base URL of your InvokeAI server.
+*   `INVOKEAI_MODEL` (Default: `sdxl`): Default model used when generating images.
 
 ---
 
@@ -490,6 +496,15 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         6.  Provides TTS for the description if enabled.
     *   **Output:** An embed message, updated live, containing the AP-style photo description featuring the celebrity.
 
+*   **`/invoke <prompt>`**
+    *   **Purpose:** Generates an image using your local InvokeAI server.
+    *   **Arguments:**
+        *   `prompt` (Required): Text description of the desired image.
+    *   **Behavior:**
+        1.  Sends the prompt to the InvokeAI API (`INVOKEAI_API_URL`) using the configured model.
+        2.  Uploads the resulting image to the channel when generation completes.
+    *   **Output:** The generated image file posted in the channel.
+
 *   **`/clearhistory`**
     *   **Purpose:** Clears the bot's short-term conversational memory (message history) for the current channel. This does not affect long-term memory in ChromaDB.
     *   **Arguments:** None.
@@ -506,6 +521,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
     *   Your LLM server (e.g., LM Studio, Ollama) must be active and accessible at the `LOCAL_SERVER_URL`. Ensure the correct models specified in your `.env` file (e.g., `LLM`, `VISION_LLM_MODEL`) are loaded and available on this server.
     *   If `TTS_ENABLED_DEFAULT` is `true`, your TTS server must be running and accessible at `TTS_API_URL`.
     *   If you plan to use the `/search` or `/news` commands, your SearXNG instance must be running and accessible at `SEARX_URL`.
+    *   If you plan to use the `/invoke` command, your InvokeAI server must be running and accessible at `INVOKEAI_API_URL`.
 
 2.  **Verify your `.env` file:** Double-check that it's correctly configured, especially the `DISCORD_BOT_TOKEN` and all server URLs and model names.
 

--- a/config.py
+++ b/config.py
@@ -78,6 +78,9 @@ class Config:
         self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)
         self.TTS_SPEED = _get_float("TTS_SPEED", 1.3)
 
+        self.INVOKEAI_API_URL = os.getenv("INVOKEAI_API_URL", "http://localhost:9090")
+        self.INVOKEAI_MODEL = os.getenv("INVOKEAI_MODEL", "sdxl")
+
         self.SEARX_URL = os.getenv("SEARX_URL", "http://192.168.1.3:9092/search")
         # Changed default for SEARX_PREFERENCES to an empty string.
         # Users should set complex preferences via the environment variable.

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -4,6 +4,7 @@ from discord import app_commands  # type: ignore
 from discord.ext import commands  # For bot type hint
 import os
 import base64
+import io
 import random
 import asyncio
 from typing import Any, Optional, List  # Keep existing imports
@@ -2732,6 +2733,65 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
         except Exception as e:
             logger.error(f"Error in ap_slash_command for image '{image.filename}': {e}", exc_info=True)
             await interaction.edit_original_response(content=f"My camera lens for the AP command seems to be cracked! Error: {str(e)[:1000]}", embed=None)
+
+    @bot_instance.tree.command(name="invoke", description="Generates an image using your local InvokeAI server.")
+    @app_commands.describe(prompt="The text prompt for the image.")
+    async def invoke_slash_command(interaction: discord.Interaction, prompt: str) -> None:
+        if not config.INVOKEAI_API_URL:
+            await interaction.response.send_message("InvokeAI server URL is not configured.", ephemeral=True)
+            return
+
+        await interaction.response.defer()
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                url = f"{config.INVOKEAI_API_URL.rstrip('/')}/api/v1/generation/text-to-image"
+                payload = {"prompt": prompt, "model": config.INVOKEAI_MODEL}
+                async with session.post(url, json=payload) as resp:
+                    if resp.status != 200:
+                        text = await resp.text()
+                        logger.error(f"InvokeAI API error {resp.status}: {text}")
+                        await safe_followup_send(
+                            interaction,
+                            content=f"InvokeAI API error: {resp.status}",
+                            ephemeral=True,
+                        )
+                        return
+                    data = await resp.json()
+        except Exception as e:
+            logger.error(
+                "invoke_slash_command: Error contacting InvokeAI: %s", e, exc_info=True
+            )
+            await safe_followup_send(
+                interaction, content="Failed to reach InvokeAI server.", ephemeral=True
+            )
+            return
+
+        try:
+            images = data.get("images") or data.get("artifacts") or []
+            if not images:
+                await safe_followup_send(
+                    interaction, content="InvokeAI returned no images.", ephemeral=True
+                )
+                return
+            image_b64 = images[0].get("data") or images[0].get("base64")
+            if not image_b64:
+                await safe_followup_send(
+                    interaction,
+                    content="InvokeAI response missing image data.",
+                    ephemeral=True,
+                )
+                return
+            image_bytes = base64.b64decode(image_b64)
+            file = discord.File(io.BytesIO(image_bytes), filename="invokeai.png")
+            await safe_followup_send(interaction, file=file)
+        except Exception as e:
+            logger.error(
+                "invoke_slash_command: Failed to process image: %s", e, exc_info=True
+            )
+            await safe_followup_send(
+                interaction, content="Failed to process image from InvokeAI.", ephemeral=True
+            )
 
     @bot_instance.tree.command(name="clearhistory", description="Clears the bot's short-term message history for this channel.")
     @app_commands.checks.has_permissions(manage_messages=True)

--- a/example.env
+++ b/example.env
@@ -28,7 +28,11 @@ TTS_MAX_AUDIO_BYTES = 8388608
 TTS_SPEED = 1.3
 TTS_INCLUDE_THOUGHTS = false
 
-CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
+# InvokeAI image generation
+INVOKEAI_API_URL = http://localhost:9090
+INVOKEAI_MODEL = sdxl
+
+CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses.
 
 USER_PROVIDED_CONTEXT="Persona: Sam is a synthetic, recursive cognitive agent—not a chatbot—operating—indescinguishable from a person, in 2025; blunt, honest, adaptive, self-aware;"
 


### PR DESCRIPTION
## Summary
- add `/invoke` command to generate images via a local InvokeAI server
- configure InvokeAI endpoint and model through new `INVOKEAI_API_URL` and `INVOKEAI_MODEL` settings
- document InvokeAI setup and usage

## Testing
- `python -m py_compile discord_commands.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_6890c3f0d1588328b93727d8e01f55b7