### PR TITLE
feat: add InvokeAI image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
 *   **Multimedia Interaction:**
     *   Analyze and describe attached images (with a creative "AP Photo" twist using a vision LLM).
     *   Transcribe attached audio files using a local Whisper model.
+*   **Image Generation (InvokeAI):**
+    *   Generate images from text prompts using a locally hosted InvokeAI server with optional model selection.
 *   **Text-to-Speech (TTS):**
     *   Voice responses for bot messages via an OpenAI TTS API compatible server.
     *   Separate TTS for "thoughts" (content within `<think>...</think>` tags) vs. main response if configured.
@@ -203,8 +205,13 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `TTS_API_URL` (Default: `http://localhost:8880/v1/audio/speech`): The endpoint of your OpenAI TTS API compatible server.
 *   `TTS_VOICE` (Default: `af_sky+af+af_nicole`): The voice to be used for TTS generation. The format may depend on your TTS server.
 *   `TTS_MAX_AUDIO_BYTES` (Default: `8388608` (8MB)): Maximum size of a single generated TTS audio clip. Longer audio will be split into parts before uploading to stay under Discord's attachment limits.
-*   `TTS_SPEED` (Default: `1.3`): Playback speed multiplier for TTS audio. Use `1.0` for normal speed.
-*   `TTS_INCLUDE_THOUGHTS` (Default: `false`): If `true`, content within `<think>...</think>` tags will also be spoken using TTS. When `false`, only the user-facing portion of the response is processed.
+    *   `TTS_SPEED` (Default: `1.3`): Playback speed multiplier for TTS audio. Use `1.0` for normal speed.
+    *   `TTS_INCLUDE_THOUGHTS` (Default: `false`): If `true`, content within `<think>...</think>` tags will also be spoken using TTS. When `false`, only the user-facing portion of the response is processed.
+
+**Image Generation (InvokeAI):**
+
+*   `INVOKEAI_API_URL` (Default: `http://localhost:9090/api/v1/generate`): Full InvokeAI generation endpoint used for the `/invoke` image generation command. Adjust if your server exposes the API at a different path.
+*   `INVOKEAI_MODEL` (Optional): Default model name to use for image generation when the `/invoke` command does not specify one.
 
 **Web Features & Scraping:**
 
@@ -476,6 +483,19 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
     *   **Requirements:** Same as `/groundnews` &mdash; you must be logged in with Playwright's persistent profile.
     *   **Output:** Embeds containing summaries for each new topic article.
 
+*   **`/invoke <prompt> [width] [height] [steps] [model]`**
+    *   **Purpose:** Generates an image based on the supplied text prompt using the configured InvokeAI server.
+    *   **Arguments:**
+        *   `prompt` (Required): The description of the image to generate.
+        *   `width` (Optional, Default: 512): Image width in pixels.
+        *   `height` (Optional, Default: 512): Image height in pixels.
+        *   `steps` (Optional, Default: 30): Number of diffusion steps to perform.
+        *   `model` (Optional): Model name to use for generation. Defaults to `INVOKEAI_MODEL` if set.
+    *   **Behavior:**
+        1.  Sends the prompt and parameters to the InvokeAI REST API.
+        2.  Waits for the response and uploads the first generated image to Discord.
+    *   **Output:** The generated image posted in the channel.
+
 *   **`/ap <image> [user_prompt]`**
     *   **Purpose:** Describes an attached image in the style of an Associated Press (AP) photo caption, with a humorous twist: a randomly chosen celebrity is creatively inserted as the main subject.
     *   **Arguments:**
@@ -506,6 +526,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
     *   Your LLM server (e.g., LM Studio, Ollama) must be active and accessible at the `LOCAL_SERVER_URL`. Ensure the correct models specified in your `.env` file (e.g., `LLM`, `VISION_LLM_MODEL`) are loaded and available on this server.
     *   If `TTS_ENABLED_DEFAULT` is `true`, your TTS server must be running and accessible at `TTS_API_URL`.
     *   If you plan to use the `/search` or `/news` commands, your SearXNG instance must be running and accessible at `SEARX_URL`.
+    *   If you plan to use the `/invoke` command, ensure your InvokeAI server is running and accessible at `INVOKEAI_API_URL`.
 
 2.  **Verify your `.env` file:** Double-check that it's correctly configured, especially the `DISCORD_BOT_TOKEN` and all server URLs and model names.
 
@@ -549,7 +570,7 @@ Several helper scripts are provided for upkeep and optional functionality:
 
 *   **Playwright Processes:** If Chromium or Playwright processes remain running after scraping, the bot has a built-in task (`cleanup_playwright_task` in `discord_events.py`) that attempts to clean them up periodically based on `PLAYWRIGHT_CLEANUP_INTERVAL_MINUTES` and `PLAYWRIGHT_IDLE_CLEANUP_THRESHOLD_MINUTES`. You can also manually kill these processes if needed.
 *   **Model Not Found Errors:** Ensure the model names specified in your `.env` file (e.g., `LLM`, `VISION_LLM_MODEL`, `FAST_LLM_MODEL`) exactly match the models loaded and available on your LLM server at `LOCAL_SERVER_URL`.
-*   **Connection Errors:** Verify that all specified server URLs (`LOCAL_SERVER_URL`, `TTS_API_URL`, `SEARX_URL`) are correct and that the respective services are running and accessible from where the bot is running.
+*   **Connection Errors:** Verify that all specified server URLs (`LOCAL_SERVER_URL`, `TTS_API_URL`, `SEARX_URL`, `INVOKEAI_API_URL`) are correct and that the respective services are running and accessible from where the bot is running.
 *   **Permissions:** If slash commands don't appear or certain commands fail, check the bot's permissions in your Discord server settings. It generally needs permissions to read messages, send messages, use embeds, attach files, and use slash commands. Some commands like `/clearhistory` or `/ingest_chatgpt_export` might require 'Manage Messages'.
 
 ---

--- a/config.py
+++ b/config.py
@@ -78,6 +78,11 @@ class Config:
         self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)
         self.TTS_SPEED = _get_float("TTS_SPEED", 1.3)
 
+        self.INVOKEAI_API_URL = os.getenv(
+            "INVOKEAI_API_URL", "http://localhost:9090/api/v1/generate"
+        )
+        self.INVOKEAI_MODEL = os.getenv("INVOKEAI_MODEL", "")
+
         self.SEARX_URL = os.getenv("SEARX_URL", "http://192.168.1.3:9092/search")
         # Changed default for SEARX_PREFERENCES to an empty string.
         # Users should set complex preferences via the environment variable.

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -6,6 +6,7 @@ import os
 import base64
 import random
 import asyncio
+import io
 from typing import Any, Optional, List  # Keep existing imports
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
@@ -49,6 +50,7 @@ from utils import (
 from rss_cache import load_seen_entries, save_seen_entries
 from twitter_cache import load_seen_tweet_ids, save_seen_tweet_ids # New import
 from ground_news_cache import load_seen_links, save_seen_links
+from invokeai_utils import generate_invokeai_image
 
 logger = logging.getLogger(__name__)
 
@@ -2654,6 +2656,48 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             if acquired_lock:
                 scrape_lock.release()
                 logger.debug("Scrape lock released for /groundtopic")
+
+
+    @bot_instance.tree.command(name="invoke", description="Generates an image using the InvokeAI server.")
+    @app_commands.describe(
+        prompt="Text prompt for the image.",
+        width="Image width in pixels.",
+        height="Image height in pixels.",
+        steps="Number of diffusion steps.",
+        model="Model to use (optional)."
+    )
+    async def invoke_slash_command(
+        interaction: discord.Interaction,
+        prompt: str,
+        width: app_commands.Range[int, 64, 2048] = 512,
+        height: app_commands.Range[int, 64, 2048] = 512,
+        steps: app_commands.Range[int, 1, 150] = 30,
+        model: Optional[str] = None,
+    ) -> None:
+        if not config.INVOKEAI_API_URL:
+            await interaction.response.send_message(
+                "InvokeAI API URL is not configured.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer()
+        logger.info(
+            "InvokeAI generation requested by %s (%s)",
+            interaction.user.name,
+            interaction.user.id,
+        )
+
+        image_bytes = await generate_invokeai_image(
+            prompt=prompt, width=width, height=height, steps=steps, model=model
+        )
+        if not image_bytes:
+            await interaction.edit_original_response(
+                content="Failed to generate image via InvokeAI."
+            )
+            return
+
+        file = discord.File(io.BytesIO(image_bytes), filename="invokeai.png")
+        await interaction.edit_original_response(content=prompt, attachments=[file])
 
 
     @bot_instance.tree.command(name="ap", description="Describes an attached image with a creative AP Photo twist.")

--- a/example.env
+++ b/example.env
@@ -28,6 +28,11 @@ TTS_MAX_AUDIO_BYTES = 8388608
 TTS_SPEED = 1.3
 TTS_INCLUDE_THOUGHTS = false
 
+# InvokeAI image generation
+# Endpoint must point directly to the generation route
+INVOKEAI_API_URL = http://localhost:9090/api/v1/generate
+INVOKEAI_MODEL =
+
 CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
 
 USER_PROVIDED_CONTEXT="Persona: Sam is a synthetic, recursive cognitive agent—not a chatbot—operating—indescinguishable from a person, in 2025; blunt, honest, adaptive, self-aware;"

--- a/invokeai_utils.py
+++ b/invokeai_utils.py
@@ -1,0 +1,84 @@
+import logging
+import base64
+from typing import Optional
+
+import aiohttp
+
+from config import config
+
+logger = logging.getLogger(__name__)
+
+async def generate_invokeai_image(
+    prompt: str,
+    width: int = 512,
+    height: int = 512,
+    steps: int = 30,
+    model: Optional[str] = None,
+) -> Optional[bytes]:
+    """Generate an image using the InvokeAI REST API.
+
+    Args:
+        prompt: Text prompt describing the desired image.
+        width: Output image width in pixels.
+        height: Output image height in pixels.
+        steps: Number of diffusion steps.
+        model: Optional model name to use for generation. Falls back to
+            ``config.INVOKEAI_MODEL`` if not provided.
+
+    Returns:
+        Raw image bytes if successful, otherwise ``None``.
+    """
+    url = config.INVOKEAI_API_URL.rstrip("/")
+    payload = {
+        "prompt": prompt,
+        "width": width,
+        "height": height,
+        "steps": steps,
+    }
+    use_model = model or config.INVOKEAI_MODEL
+    if use_model:
+        payload["model"] = use_model
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url, json=payload, timeout=aiohttp.ClientTimeout(total=120)
+            ) as resp:
+                if resp.status == 405:
+                    # Some InvokeAI community builds expose generation via GET.
+                    async with session.get(
+                        url, params=payload, timeout=aiohttp.ClientTimeout(total=120)
+                    ) as get_resp:
+                        if get_resp.status != 200:
+                            logger.error(
+                                "InvokeAI API returned status %s: %s",
+                                get_resp.status,
+                                await get_resp.text(),
+                            )
+                            return None
+                        data = await get_resp.json()
+                elif resp.status != 200:
+                    logger.error(
+                        "InvokeAI API returned status %s: %s",
+                        resp.status,
+                        await resp.text(),
+                    )
+                    return None
+                else:
+                    data = await resp.json()
+    except Exception as e:  # pragma: no cover - network errors
+        logger.error("Error contacting InvokeAI API: %s", e, exc_info=True)
+        return None
+
+    images = data.get("images")
+    if not images:
+        logger.error("InvokeAI API response contained no images.")
+        return None
+    image_b64 = images[0].get("image_base64") or images[0].get("base64")
+    if not image_b64:
+        logger.error("InvokeAI API response missing base64 image data.")
+        return None
+    try:
+        return base64.b64decode(image_b64)
+    except Exception as e:  # pragma: no cover - decode errors
+        logger.error("Failed to decode InvokeAI image: %s", e, exc_info=True)
+        return None


### PR DESCRIPTION
## Summary
- integrate InvokeAI by adding `/invoke` slash command
- add `INVOKEAI_API_URL` config and helper module for API calls
- document InvokeAI setup and options
- handle InvokeAI endpoint differences with configurable URL and GET fallback
- support selecting InvokeAI models via optional command argument and `INVOKEAI_MODEL` default

## Testing
- `python -m py_compile config.py discord_commands.py invokeai_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6890c3f0d1588328b93727d8e01f55b7