### PR TITLE
Ban em dash via logit bias in OpenAI requests

### DIFF
--- a/discord_commands.py
+++ b/discord_commands.py
@@ -38,6 +38,7 @@ from web_utils import (
     scrape_ground_news_topic,
     fetch_rss_entries
 )
+from logit_biases import LOGIT_BIAS_EM_DASH_STR
 from audio_utils import send_tts_audio
 from utils import (
     parse_time_string_to_delta,
@@ -228,6 +229,7 @@ async def process_rss_feed(
                 max_tokens=500,
                 temperature=0.5,
                 stream=False,
+                logit_bias=LOGIT_BIAS_EM_DASH_STR,
             )
             summary = response.choices[0].message.content.strip() if response.choices else ""
             if summary and summary != "[LLM summarization failed]":
@@ -353,6 +355,7 @@ async def process_ground_news(
                 max_tokens=500,
                 temperature=0.5,
                 stream=False,
+                logit_bias=LOGIT_BIAS_EM_DASH_STR,
             )
             summary = response.choices[0].message.content.strip() if response.choices else ""
             if summary and summary != "[LLM summarization failed]":
@@ -506,6 +509,7 @@ async def process_ground_news_topic(
                 max_tokens=500,
                 temperature=0.5,
                 stream=False,
+                logit_bias=LOGIT_BIAS_EM_DASH_STR,
             )
             summary = response.choices[0].message.content.strip() if response.choices else ""
             if summary and summary != "[LLM summarization failed]":
@@ -631,6 +635,7 @@ async def describe_image(image_url: str) -> Optional[str]:
             messages=prompt_messages,
             max_tokens=150,
             temperature=0.3,
+            logit_bias=LOGIT_BIAS_EM_DASH_STR,
         )
         if response.choices and response.choices[0].message and response.choices[0].message.content:
             return response.choices[0].message.content.strip()
@@ -1053,7 +1058,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                         ],
                         max_tokens=250,
                         temperature=0.3,
-                        stream=False
+                        stream=False,
+                        logit_bias=LOGIT_BIAS_EM_DASH_STR,
                     )
                     if summary_response.choices and summary_response.choices[0].message and summary_response.choices[0].message.content:
                         article_summary = summary_response.choices[0].message.content.strip()
@@ -1407,7 +1413,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                         ],
                         max_tokens=250,
                         temperature=0.3,
-                        stream=False
+                        stream=False,
+                        logit_bias=LOGIT_BIAS_EM_DASH_STR,
                     )
                     if summary_response_search.choices and summary_response_search.choices[0].message and summary_response_search.choices[0].message.content:
                         page_summary = summary_response_search.choices[0].message.content.strip()
@@ -1742,6 +1749,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                             max_tokens=500,
                             temperature=0.5,
                             stream=False,
+                            logit_bias=LOGIT_BIAS_EM_DASH_STR,
                         )
                         summary = response.choices[0].message.content.strip() if response.choices else ""
                         if summary and summary != "[LLM summarization failed]":

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -23,6 +23,7 @@ from utils import (
 # Import functions for post-stream processing
 from rag_chroma_manager import ingest_conversation_to_chromadb
 from audio_utils import send_tts_audio
+from logit_biases import LOGIT_BIAS_EM_DASH_STR
 
 
 logger = logging.getLogger(__name__)
@@ -177,7 +178,10 @@ async def get_simplified_llm_stream(
         final_llm_stream = await llm_client.chat.completions.create(
             model=final_stream_model,
             messages=api_messages,
-            max_tokens=config.MAX_COMPLETION_TOKENS, stream=True, temperature=0.7,
+            max_tokens=config.MAX_COMPLETION_TOKENS,
+            stream=True,
+            temperature=0.7,
+            logit_bias=LOGIT_BIAS_EM_DASH_STR,
         )
         return final_llm_stream, prompt_messages
     except Exception as e:
@@ -736,8 +740,13 @@ async def get_description_for_image(llm_client: Any, image_path: str) -> str:
         response = await llm_client.chat.completions.create(
             model=config.VISION_LLM_MODEL,
             messages=prompt_messages,
-            max_tokens=config.MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION if hasattr(config, 'MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION') else 300, # Use a specific max_tokens for descriptions
-            temperature=0.3 # Lower temperature for more factual descriptions
+            max_tokens=(
+                config.MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION
+                if hasattr(config, "MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION")
+                else 300
+            ),  # Use a specific max_tokens for descriptions
+            temperature=0.3,  # Lower temperature for more factual descriptions
+            logit_bias=LOGIT_BIAS_EM_DASH_STR,
         )
 
         if response.choices and response.choices[0].message and response.choices[0].message.content:

--- a/llm_request_processor.py
+++ b/llm_request_processor.py
@@ -14,6 +14,7 @@ from config import config # For gettweets and other command-specific configs
 import base64 # For ap_command
 import random # For ap_command
 import os # For ingest_command
+from logit_biases import LOGIT_BIAS_EM_DASH_STR
 
 # Need to import the inline Pydantic models from discord_commands if they are not moved to common_models
 # For now, assuming they will be moved or this processor will be adapted.
@@ -150,7 +151,10 @@ async def llm_request_processor_task(bot_state: BotState, llm_client: Any, bot_i
                                         {"role": "system", "content": "You are an expert news summarizer."},
                                         {"role": "user", "content": summarization_prompt}
                                     ],
-                                    max_tokens=250, temperature=0.3, stream=False
+                                    max_tokens=250,
+                                    temperature=0.3,
+                                    stream=False,
+                                    logit_bias=LOGIT_BIAS_EM_DASH_STR,
                                 )
                                 if summary_response.choices and summary_response.choices[0].message and summary_response.choices[0].message.content:
                                     article_summary = summary_response.choices[0].message.content.strip()

--- a/logit_biases.py
+++ b/logit_biases.py
@@ -1,0 +1,52 @@
+"""Utility constants for logit bias settings."""
+from typing import Dict
+
+# Mapping of token IDs representing the em dash and common variants to a
+# strong negative bias. This discourages the model from producing these tokens.
+LOGIT_BIAS_EM_DASH: Dict[int, int] = {
+      2322: -100,  # '\u2014'
+      2733: -100,  # ' \u2014'
+      8290: -100,  # '\u2014\u2014'
+     20962: -100,  # '\u2014\u2014\u2014\u2014'
+     35251: -100,  # '\u2014and'
+     41648: -100,  # '\u2014\u2014\u2014\u2014\u2014\u2014\u2014\u2014'
+     51692: -100,  # '\u2014the'
+     54067: -100,  # '.\u2014'
+     65363: -100,  # '\u2014a'
+     87643: -100,  # '\u2014\n\n'
+     94012: -100,  # '\u2014but'
+     94828: -100,  # '\u2014\u2014... (long run)'
+     96754: -100,  # '.\u201d\u2014'
+    108181: -100,  # '\u2014that'
+    114635: -100,  # '\u2014it'
+    118256: -100,  # '\u2014in'
+    121630: -100,  # '\u2014or'
+    121655: -100,  # '\u2014to'
+    123101: -100,  # '\u2014\n'
+    126952: -100,  # '\u2014I'
+    127126: -100,  # '\u201d\u2014'
+    134820: -100,  # ' \u2014\n'
+    137419: -100,  # '\u2014which'
+    140135: -100,  # ' \u2014\u2014'
+    142654: -100,  # ' \u2014\n\n'
+    144129: -100,  # ')\u2014'
+    144787: -100,  # '\u2014is'
+    147994: -100,  # ',\u2014'
+    155638: -100,  # '\u2014as'
+    160984: -100,  # '\u2014not'
+    169785: -100,  # '\u2014you'
+    178328: -100,  # '\u2014from'
+    180500: -100,  # '\u2014including'
+    183122: -100,  # '\u2014for'
+    183862: -100,  # '\u200b\u2014'
+    187349: -100,  # '\u2014they'
+    188860: -100,  # '\u2014all'
+    190702: -100,  # '\u2014with'
+    196615: -100,  # '\u2014we'
+    197618: -100,  # '\u2014even'
+}
+
+# The OpenAI API expects string keys for the logit_bias mapping.
+LOGIT_BIAS_EM_DASH_STR: Dict[str, int] = {str(k): v for k, v in LOGIT_BIAS_EM_DASH.items()}
+
+__all__ = ["LOGIT_BIAS_EM_DASH_STR"]

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -13,6 +13,7 @@ from chromadb.errors import InternalError
 
 from config import config
 from common_models import MsgNode
+from logit_biases import LOGIT_BIAS_EM_DASH_STR
 
 
 logger = logging.getLogger(__name__)
@@ -214,9 +215,10 @@ Do not include any explanations or conversational text outside the JSON object.
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
             ],
-            max_tokens=8192, # Increased max_tokens for potentially larger JSON outputs
+            max_tokens=8192,  # Increased max_tokens for potentially larger JSON outputs
             temperature=0.2,
             stream=False,
+            logit_bias=LOGIT_BIAS_EM_DASH_STR,
             **response_format_arg
         )
 
@@ -260,7 +262,8 @@ Do not include any explanations or conversational text outside the JSON object.
                     ],
                     max_tokens=2048,
                     temperature=0.2,
-                    stream=False
+                    stream=False,
+                    logit_bias=LOGIT_BIAS_EM_DASH_STR,
                 )
                 if response.choices and response.choices[0].message and response.choices[0].message.content:
                     raw_content = response.choices[0].message.content.strip()
@@ -317,7 +320,8 @@ async def distill_conversation_to_sentence_llm(llm_client: Any, text_to_distill:
             ],
             max_tokens=2048,
             temperature=0.5,
-            stream=False
+            stream=False,
+            logit_bias=LOGIT_BIAS_EM_DASH_STR,
         )
         if response.choices and response.choices[0].message and response.choices[0].message.content:
             distilled = response.choices[0].message.content.strip()
@@ -370,7 +374,8 @@ async def synthesize_retrieved_contexts_llm(llm_client: Any, retrieved_contexts:
             ],
             max_tokens=3072,
             temperature=0.6,
-            stream=False
+            stream=False,
+            logit_bias=LOGIT_BIAS_EM_DASH_STR,
         )
         if response.choices and response.choices[0].message and response.choices[0].message.content:
             synthesized_context = response.choices[0].message.content.strip()
@@ -417,6 +422,7 @@ async def merge_memory_snippet_with_summary_llm(
             max_tokens=2048,
             temperature=0.4,
             stream=False,
+            logit_bias=LOGIT_BIAS_EM_DASH_STR,
         )
         if response.choices and response.choices[0].message and response.choices[0].message.content:
             return response.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- add mapping of em-dash token ids with strong negative bias
- apply this logit bias to every OpenAI chat completion request

## Testing
- `python -m py_compile logit_biases.py llm_handling.py rag_chroma_manager.py discord_commands.py llm_request_processor.py`


------
https://chatgpt.com/codex/tasks/task_e_6892bd1b15c08328bcfe775c7549b658