### PR TITLE
Annotate relative dates with absolute timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DiscordSam is an advanced, context-aware Discord bot designed to provide intelli
     *   Conversations are "distilled" into keyword-rich sentences for efficient semantic search.
     *   Extracts structured data (entities, relations, observations) from conversations to build a knowledge base.
     *   Can ingest ChatGPT export files to import prior conversation history.
+    *   Automatically annotates relative date expressions with exact timestamps to improve date-based retrieval.
 *   **Web Capabilities:**
     *   Scrape website content (with Playwright, falling back to BeautifulSoup) and YouTube transcripts.
     *   Generate textual descriptions of webpage screenshots using a vision LLM.

--- a/discord_events.py
+++ b/discord_events.py
@@ -22,7 +22,11 @@ from llm_handling import (
 from rag_chroma_manager import (
     retrieve_and_prepare_rag_context
 )
-from utils import detect_urls, cleanup_playwright_processes
+from utils import (
+    detect_urls,
+    cleanup_playwright_processes,
+    append_absolute_dates,
+)
 from web_utils import scrape_website, fetch_youtube_transcript
 from audio_utils import transcribe_audio_file, send_tts_audio, load_whisper_model
 from timeline_pruner import prune_and_summarize
@@ -241,7 +245,18 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                         logger.error(f"Error processing audio attachment '{attachment.filename}': {e}", exc_info=True)
                     break
 
-        current_message_content_parts.append({"type": "text", "text": user_message_text_for_processing if user_message_text_for_processing else ""})
+        user_message_text_for_processing = append_absolute_dates(
+            user_message_text_for_processing
+        )
+
+        current_message_content_parts.append(
+            {
+                "type": "text",
+                "text": user_message_text_for_processing
+                if user_message_text_for_processing
+                else "",
+            }
+        )
 
         image_added_to_prompt = False; images_processed_count = 0
         if message.attachments:

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -14,6 +14,7 @@ from chromadb.errors import InternalError
 from config import config
 from common_models import MsgNode
 from logit_biases import LOGIT_BIAS_UNWANTED_TOKENS_STR
+from utils import append_absolute_dates
 
 
 logger = logging.getLogger(__name__)
@@ -459,7 +460,12 @@ async def update_retrieved_memories(
         except Exception as e_add:
             logger.error(f"Failed to store merged memory update {doc_id}: {e_add}", exc_info=True)
 
-async def retrieve_and_prepare_rag_context(llm_client: Any, query: str, n_results_sentences: int = config.RAG_NUM_DISTILLED_SENTENCES_TO_FETCH) -> Tuple[Optional[str], Optional[List[Tuple[str, str]]]]:
+async def retrieve_and_prepare_rag_context(
+    llm_client: Any,
+    query: str,
+    n_results_sentences: int = config.RAG_NUM_DISTILLED_SENTENCES_TO_FETCH,
+) -> Tuple[Optional[str], Optional[List[Tuple[str, str]]]]:
+    query = append_absolute_dates(query)
     if not chroma_client or not distilled_chat_summary_collection or not chat_history_collection:
         logger.warning("ChromaDB collections not available, skipping RAG context retrieval.")
         return None, None

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ playwright>=1.30.0
 youtube-transcript-api>=0.6.0
 numpy>=1.23.0
 psutil>=5.9.0
+dateparser>=1.1.8


### PR DESCRIPTION
## Summary
- add `dateparser` dependency
- add `append_absolute_dates` utility to tag relative date phrases with absolute timestamps
- apply date annotation in message handling and RAG queries, and document the feature

## Testing
- `python -m py_compile utils.py discord_events.py rag_chroma_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68930463b22c8328b0ca42f52e601b70