### PR TITLE
Fix date annotation to ignore explicit timestamps

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import unittest
+from datetime import datetime, timezone
+
+from utils import append_absolute_dates
+
+
+class AppendAbsoluteDatesTest(unittest.TestCase):
+    def test_relative_phrase(self) -> None:
+        base_time = datetime(2024, 5, 8, tzinfo=timezone.utc)
+        text = "Let's meet tomorrow."
+        result = append_absolute_dates(text, current_time=base_time)
+        self.assertIn("tomorrow (2024-05-09 00:00 UTC)", result)
+
+    def test_absolute_date_unchanged(self) -> None:
+        text = "Tell me (2025-08-05 18:00 Mountain Daylight Time) about gogurtius."
+        result = append_absolute_dates(text)
+        self.assertEqual(result, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -39,6 +39,16 @@ def detect_urls(message_text: str) -> List[str]:
     url_pattern = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+')
     return url_pattern.findall(message_text)
 
+RELATIVE_DATE_PATTERN = re.compile(
+    r'\b('
+    r'yesterday|today|tomorrow|tonight|'
+    r'this\s+(?:morning|afternoon|evening)|'
+    r'last\s+\w+|next\s+\w+|'
+    r'\d+\s+(?:seconds?|minutes?|hours?|days?|weeks?|months?|years?)\s+(?:ago|from\\s+now)|'
+    r'in\s+\d+\s+(?:seconds?|minutes?|hours?|days?|weeks?|months?|years?)'
+    r')\b',
+    re.IGNORECASE,
+)
 
 def append_absolute_dates(
     text: str, current_time: Optional[datetime] = None
@@ -58,6 +68,7 @@ def append_absolute_dates(
     str
         Text where each detected relative date phrase is followed by its
         absolute representation, e.g. ``"tomorrow (2024-05-10 00:00 UTC)"``.
+        Phrases already containing explicit dates are left unmodified.
     """
 
     if not text:
@@ -70,6 +81,8 @@ def append_absolute_dates(
 
     for phrase, dt in results:
         if "(" in phrase:
+            continue
+        if not RELATIVE_DATE_PATTERN.search(phrase):
             continue
         if dt.tzinfo is None:
             dt = dt.replace(tzinfo=current_time.tzinfo)


### PR DESCRIPTION
## Summary
- avoid annotating phrases that already contain explicit dates
- add unit tests for relative and absolute date handling

## Testing
- `python -m unittest tests/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68931a058b7c8328af31fab7cf19bb2d