### PR TITLE
Strip non-breaking spaces from RSS titles

### DIFF
--- a/tests/test_rss_titles.py
+++ b/tests/test_rss_titles.py
@@ -1,0 +1,59 @@
+import asyncio
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from web_utils import fetch_rss_entries
+
+
+class DummyResponse:
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    async def text(self) -> str:
+        return self._body
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def __aenter__(self) -> "DummyResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class DummyClientSession:
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    async def __aenter__(self) -> "DummyClientSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def get(self, url: str, timeout: int) -> DummyResponse:
+        return DummyResponse(self._body)
+
+
+class FetchRSSTitleTest(unittest.TestCase):
+    def test_fetch_rss_entries_strips_nbsp(self) -> None:
+        recent_date = datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT")
+        rss_body = (
+            f"<rss><channel><item><title><![CDATA[Test&nbsp;Title]]></title><link>http://example.com</link>"
+            f"<guid>1</guid><pubDate>{recent_date}</pubDate><description>desc</description>"
+            f"</item></channel></rss>"
+        )
+        with patch("aiohttp.ClientSession", lambda *args, **kwargs: DummyClientSession(rss_body)):
+            entries = asyncio.run(fetch_rss_entries("http://example.com/rss"))
+        self.assertTrue(entries)
+        self.assertEqual(entries[0]["title"], "Test Title")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,9 @@
 import unittest
 from datetime import datetime, timezone
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from utils import append_absolute_dates
 

--- a/web_utils.py
+++ b/web_utils.py
@@ -9,6 +9,7 @@ import random
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 import hashlib
+import html
 
 import aiohttp
 from playwright.async_api import async_playwright, TimeoutError as PlaywrightTimeoutError # type: ignore
@@ -758,9 +759,11 @@ async def fetch_rss_entries(feed_url: str) -> List[Dict[str, Any]]:
                 and not link_url.startswith("https://www.cbsnews.com/news/")
             ):
                 continue
+            raw_title = it.findtext("title") or ""
+            title = html.unescape(raw_title).replace("\xa0", " ").strip()
 
             entries.append({
-                "title": it.findtext("title") or "",
+                "title": title,
                 "link": link_url,
                 "guid": it.findtext("guid") or link_url or "",
                 "pubDate": pub_date_str,


### PR DESCRIPTION
## Summary
- Clean RSS item titles by unescaping HTML and removing non-breaking spaces
- Add regression test to ensure &nbsp; is stripped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68944411af18832889dfb35bb29be486