### PR TITLE
Load Whisper model on demand with idle unload

### DIFF
--- a/discord_events.py
+++ b/discord_events.py
@@ -28,7 +28,7 @@ from utils import (
     append_absolute_dates,
 )
 from web_utils import scrape_website, fetch_youtube_transcript
-from audio_utils import transcribe_audio_file, send_tts_audio, load_whisper_model
+from audio_utils import transcribe_audio_file, send_tts_audio
 from timeline_pruner import prune_and_summarize
 
 logger = logging.getLogger(__name__)
@@ -129,7 +129,6 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         if not bot_instance or not bot_instance.user:
             logger.critical("Bot user not available on_ready. This is highly unusual.")
             return
-        load_whisper_model()
         logger.info(f'{bot_instance.user.name} (ID: {bot_instance.user.id}) has connected to Discord!')
         # ... (rest of on_ready remains the same)
         logger.info(f"discord.py version: {discord.__version__}")

--- a/main_bot.py
+++ b/main_bot.py
@@ -9,8 +9,8 @@ from config import config, require_bot_token  # ``require_bot_token`` enforces t
 from state import BotState # Assuming state.py is in the same directory
 
 # Import utility and manager modules
-from rag_chroma_manager import initialize_chromadb # For initializing ChromaDB
-# audio_utils contains load_whisper_model, which is called in on_ready event
+from rag_chroma_manager import initialize_chromadb  # For initializing ChromaDB
+# audio_utils handles Whisper model loading on demand when needed
 
 # Import setup functions for commands and events
 from discord_commands import setup_commands


### PR DESCRIPTION
## Summary
- Load Whisper model lazily and unload it after 60s of inactivity to free VRAM
- Transcribe audio by loading the Whisper model on demand
- Remove eager Whisper model load on bot startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689467537b8c832884fed8d47cccc211