### PR TITLE
feat: add OpenAI responses API toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `FAST_LLM_MODEL` (Default: Same as `LLM`): The model used for tasks where speed is preferred over maximum quality, such as intermediate summarizations or quick classifications.
 *   `VISION_LLM_MODEL` (Default: `llava`): The model used for tasks involving image understanding (e.g., the `/ap` command or describing screenshots).
 *   `LLM_SUPPORTS_JSON_MODE` (Default: `false`): Set to `true` if your LLM server and the selected model support JSON mode for structured output (e.g., for entity extraction).
+*   `USE_RESPONSES_API` (Default: `false`): When `true`, use OpenAI's Responses API instead of legacy Chat Completions. System prompts are passed via the `instructions` field and model names may require the orchestrator variant (e.g., `gpt-4o`).
 *   `MAX_MESSAGE_HISTORY` (Default: `10`): The maximum number of recent messages (user and assistant turns) to include in the short-term context sent to the LLM.
 *   `MAX_COMPLETION_TOKENS` (Default: `2048`): The maximum number of tokens the LLM is allowed to generate in a single response.
 

--- a/config.py
+++ b/config.py
@@ -60,6 +60,7 @@ class Config:
         self.FAST_LLM_MODEL = os.getenv("FAST_LLM_MODEL", self.LLM_MODEL)
         self.LLM_API_KEY = os.getenv("LLM_API_KEY", "")
         self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False) # New Flag
+        self.USE_RESPONSES_API = _get_bool("USE_RESPONSES_API", False)
         self.SYSTEM_PROMPT_FILE = os.getenv("SYSTEM_PROMPT_FILE", "system_prompt.md")
 
         self.ALLOWED_CHANNEL_IDS = _parse_int_list("ALLOWED_CHANNEL_IDS")

--- a/example.env
+++ b/example.env
@@ -6,6 +6,7 @@ MISTRAL_API_KEY =
 
 LLM_API_KEY =
 LLM_SUPPORTS_JSON_MODE = true
+USE_RESPONSES_API = false
 
 SYSTEM_PROMPT_FILE = system_prompt.md
 

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -4,7 +4,7 @@ import base64
 import os
 from typing import List, Any, Optional, Union, Tuple, cast
 import discord
-from openai import AsyncStream, OpenAIError # type: ignore
+from openai import AsyncStream, OpenAIError, BadRequestError  # type: ignore
 from datetime import datetime
 
 # Assuming config is imported from config.py
@@ -24,6 +24,8 @@ from utils import (
 from rag_chroma_manager import ingest_conversation_to_chromadb
 from audio_utils import send_tts_audio
 from logit_biases import LOGIT_BIAS_UNWANTED_TOKENS_STR
+from openai_api import create_chat_completion, extract_text
+from openai import BadRequestError
 
 
 logger = logging.getLogger(__name__)
@@ -162,7 +164,7 @@ async def get_simplified_llm_stream(
     llm_client: Any,
     prompt_messages: List[MsgNode],
     is_vision_request: bool
-) -> Tuple[Optional[AsyncStream], List[MsgNode]]:
+) -> Tuple[Optional[Any], List[MsgNode]]:
     if not prompt_messages:
         raise ValueError("Prompt messages cannot be empty for get_simplified_llm_stream.")
 
@@ -170,31 +172,57 @@ async def get_simplified_llm_stream(
 
     final_stream_model = config.VISION_LLM_MODEL if is_vision_request else config.LLM_MODEL
     logger.info(f"Using model for final streaming response: {final_stream_model}")
+    api_messages = [msg_node.to_dict() for msg_node in prompt_messages]
     try:
-        api_messages = []
-        for msg_node in prompt_messages:
-            api_messages.append(msg_node.to_dict())
-
-        final_llm_stream = await llm_client.chat.completions.create(
+        final_llm_stream = await create_chat_completion(
+            llm_client,
+            api_messages,
             model=final_stream_model,
-            messages=api_messages,
             max_tokens=config.MAX_COMPLETION_TOKENS,
-            stream=True,
             temperature=0.7,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
+            stream=True,
         )
         return final_llm_stream, prompt_messages
+    except BadRequestError as e:
+        err_param = (getattr(e, "body", {}) or {}).get("error", {}).get("param")
+        if config.USE_RESPONSES_API and err_param == "stream":
+            logger.warning(
+                f"Streaming not supported for model {final_stream_model}; retrying without stream."
+            )
+            try:
+                final_response = await create_chat_completion(
+                    llm_client,
+                    api_messages,
+                    model=final_stream_model,
+                    max_tokens=config.MAX_COMPLETION_TOKENS,
+                    temperature=0.7,
+                    logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
+                    stream=False,
+                )
+                return final_response, prompt_messages
+            except Exception as inner_e:
+                e = inner_e
+        logger.error(
+            f"Failed to create LLM response for model {final_stream_model}: {e}",
+            exc_info=True,
+        )
     except Exception as e:
-        logger.error(f"Failed to create LLM stream for final response with model {final_stream_model}: {e}", exc_info=True)
-        try:
-            for i, msg in enumerate(prompt_messages):
-                content_detail = str(msg.content)
-                if isinstance(msg.content, list):
-                    content_detail = f"List of {len(msg.content)} parts: {[item.get('type') if isinstance(item,dict) else type(item) for item in msg.content]}"
-                logger.error(f"Problematic prompt message [{i}]: Role='{msg.role}', ContentType='{type(msg.content)}', Content='{content_detail[:500]}'")
-        except Exception as log_e:
-            logger.error(f"Error during logging of problematic messages: {log_e}")
-        return None, prompt_messages
+        logger.error(
+            f"Failed to create LLM stream for final response with model {final_stream_model}: {e}",
+            exc_info=True,
+        )
+    try:
+        for i, msg in enumerate(prompt_messages):
+            content_detail = str(msg.content)
+            if isinstance(msg.content, list):
+                content_detail = f"List of {len(msg.content)} parts: {[item.get('type') if isinstance(item,dict) else type(item) for item in msg.content]}"
+            logger.error(
+                f"Problematic prompt message [{i}]: Role='{msg.role}', ContentType='{type(msg.content)}', Content='{content_detail[:500]}'"
+            )
+    except Exception as log_e:
+        logger.error(f"Error during logging of problematic messages: {log_e}")
+    return None, prompt_messages
 
 async def _stream_llm_handler(
     interaction_or_message: Union[discord.Interaction, discord.Message],
@@ -301,37 +329,70 @@ async def _stream_llm_handler(
         last_edit_time = asyncio.get_event_loop().time()
         accumulated_delta_for_update = ""
 
-        if current_initial_message:
-            initial_display_embed = discord.Embed(
-                title=title,
-                description=response_prefix + "⏳ Streaming response...",
-                color=config.EMBED_COLOR["incomplete"],
-            )
-            current_initial_message = await safe_message_edit(
-                current_initial_message,
-                channel,
-                embed=initial_display_embed,
-            )
-            sent_messages[0] = current_initial_message
+        if hasattr(stream, "__aiter__"):
+            if current_initial_message:
+                initial_display_embed = discord.Embed(
+                    title=title,
+                    description=response_prefix + "⏳ Streaming response...",
+                    color=config.EMBED_COLOR["incomplete"],
+                )
+                current_initial_message = await safe_message_edit(
+                    current_initial_message,
+                    channel,
+                    embed=initial_display_embed,
+                )
+                sent_messages[0] = current_initial_message
 
-        async for chunk_data in stream:
-            delta_content = ""
-            if chunk_data.choices and chunk_data.choices[0].delta:
-                delta_content = chunk_data.choices[0].delta.content or ""
+            async for chunk_data in stream:
+                delta_content = ""
+                if config.USE_RESPONSES_API:
+                    event_type = getattr(chunk_data, "type", "")
+                    if event_type == "response.output_text.delta":
+                        delta_content = getattr(chunk_data, "delta", "") or ""
+                    else:
+                        continue
+                else:
+                    if chunk_data.choices and chunk_data.choices[0].delta:
+                        delta_content = chunk_data.choices[0].delta.content or ""
 
-            if delta_content:
-                full_response_content += delta_content
-                accumulated_delta_for_update += delta_content
+                if delta_content:
+                    full_response_content += delta_content
+                    accumulated_delta_for_update += delta_content
 
-            current_time = asyncio.get_event_loop().time()
-            if accumulated_delta_for_update and \
-               (current_time - last_edit_time >= (1.0 / config.EDITS_PER_SECOND) or \
-                len(accumulated_delta_for_update) > 200):
+                current_time = asyncio.get_event_loop().time()
+                if accumulated_delta_for_update and \
+                   (current_time - last_edit_time >= (1.0 / config.EDITS_PER_SECOND) or \
+                    len(accumulated_delta_for_update) > 200):
 
+                    display_text = response_prefix + full_response_content
+                    text_chunks = chunk_text(display_text, config.EMBED_MAX_LENGTH)
+                    accumulated_delta_for_update = ""
+
+                    for i, chunk_content_part in enumerate(text_chunks):
+                        embed = discord.Embed(
+                            title=title if i == 0 else f"{title} (cont.)",
+                            description=chunk_content_part,
+                            color=config.EMBED_COLOR["incomplete"],
+                        )
+                        if i < len(sent_messages):
+                            sent_messages[i] = await safe_message_edit(
+                                sent_messages[i],
+                                channel,
+                                embed=embed,
+                            )
+                        else:
+                            if channel:
+                                new_msg = await channel.send(embed=embed)
+                                sent_messages.append(new_msg)
+                            else:
+                                logger.error(f"Cannot send overflow chunk {i+1} for '{title}': channel is None.")
+                                break
+                    last_edit_time = current_time
+                    await asyncio.sleep(config.STREAM_EDIT_THROTTLE_SECONDS)
+
+            if accumulated_delta_for_update:
                 display_text = response_prefix + full_response_content
                 text_chunks = chunk_text(display_text, config.EMBED_MAX_LENGTH)
-                accumulated_delta_for_update = ""
-
                 for i, chunk_content_part in enumerate(text_chunks):
                     embed = discord.Embed(
                         title=title if i == 0 else f"{title} (cont.)",
@@ -344,34 +405,12 @@ async def _stream_llm_handler(
                             channel,
                             embed=embed,
                         )
-                    else:
-                        if channel:
-                            new_msg = await channel.send(embed=embed)
-                            sent_messages.append(new_msg)
-                        else:
-                            logger.error(f"Cannot send overflow chunk {i+1} for '{title}': channel is None.")
-                            break
-                last_edit_time = current_time
+                    elif channel:
+                        sent_messages.append(await channel.send(embed=embed))
                 await asyncio.sleep(config.STREAM_EDIT_THROTTLE_SECONDS)
+        else:
+            full_response_content = extract_text(stream)
 
-        if accumulated_delta_for_update:
-            display_text = response_prefix + full_response_content
-            text_chunks = chunk_text(display_text, config.EMBED_MAX_LENGTH)
-            for i, chunk_content_part in enumerate(text_chunks):
-                embed = discord.Embed(
-                    title=title if i == 0 else f"{title} (cont.)",
-                    description=chunk_content_part,
-                    color=config.EMBED_COLOR["incomplete"],
-                )
-                if i < len(sent_messages):
-                    sent_messages[i] = await safe_message_edit(
-                        sent_messages[i],
-                        channel,
-                        embed=embed,
-                    )
-                elif channel:
-                    sent_messages.append(await channel.send(embed=embed))
-            await asyncio.sleep(config.STREAM_EDIT_THROTTLE_SECONDS)
 
         final_display_text = response_prefix + full_response_content
         final_chunks = chunk_text(final_display_text, config.EMBED_MAX_LENGTH)
@@ -737,20 +776,21 @@ async def get_description_for_image(llm_client: Any, image_path: str) -> str:
         ]
 
         logger.debug(f"Sending image description request to model: {config.VISION_LLM_MODEL}")
-        response = await llm_client.chat.completions.create(
+        response = await create_chat_completion(
+            llm_client,
+            prompt_messages,
             model=config.VISION_LLM_MODEL,
-            messages=prompt_messages,
             max_tokens=(
                 config.MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION
                 if hasattr(config, "MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION")
                 else 300
-            ),  # Use a specific max_tokens for descriptions
-            temperature=0.3,  # Lower temperature for more factual descriptions
+            ),
+            temperature=0.3,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
 
-        if response.choices and response.choices[0].message and response.choices[0].message.content:
-            description = response.choices[0].message.content.strip()
+        description = extract_text(response)
+        if description:
             logger.info(f"Successfully generated description for image {image_path}: {description[:100]}...")
             return description
         else:

--- a/llm_request_processor.py
+++ b/llm_request_processor.py
@@ -15,6 +15,7 @@ import base64 # For ap_command
 import random # For ap_command
 import os # For ingest_command
 from logit_biases import LOGIT_BIAS_UNWANTED_TOKENS_STR
+from openai_api import create_chat_completion, extract_text
 
 # Need to import the inline Pydantic models from discord_commands if they are not moved to common_models
 # For now, assuming they will be moved or this processor will be adapted.
@@ -145,19 +146,19 @@ async def llm_request_processor_task(bot_state: BotState, llm_client: Any, bot_i
                                     f"Article Title: {article_title}\n"
                                     f"Article Content:\n{scraped_content[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT*2]}"
                                 )
-                                summary_response = await llm_client.chat.completions.create(
-                                    model=config.FAST_LLM_MODEL,
-                                    messages=[
+                                summary_response = await create_chat_completion(
+                                    llm_client,
+                                    [
                                         {"role": "system", "content": "You are an expert news summarizer."},
                                         {"role": "user", "content": summarization_prompt}
                                     ],
+                                    model=config.FAST_LLM_MODEL,
                                     max_tokens=250,
                                     temperature=0.3,
-                                    stream=False,
                                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                                 )
-                                if summary_response.choices and summary_response.choices[0].message and summary_response.choices[0].message.content:
-                                    article_summary = summary_response.choices[0].message.content.strip()
+                                article_summary = extract_text(summary_response)
+                                if article_summary:
                                     article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
                                     store_news_summary(topic=topic, url=article_url, summary_text=article_summary) # Assuming this is thread-safe or handled
                                 else:

--- a/openai_api.py
+++ b/openai_api.py
@@ -1,0 +1,99 @@
+"""Utility functions to abstract OpenAI API differences."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+from config import config
+
+
+async def create_chat_completion(
+    llm_client: Any,
+    messages: Sequence[Dict[str, Any]],
+    model: str,
+    max_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    logit_bias: Optional[Dict[str, int]] = None,
+    stream: bool = False,
+) -> Any:
+    """Create a response from OpenAI using either Chat Completions or Responses.
+
+    Args:
+        llm_client: The OpenAI client instance.
+        messages: List of message dicts following the Chat Completions format.
+            Messages with role ``developer`` are treated as hidden instructions.
+            In Chat Completions they are converted to ``system`` messages; in
+            Responses they remain ``developer`` messages.
+        model: Model name to use.
+        max_tokens: Maximum tokens for the response. For Chat Completions this
+            is sent as ``max_completion_tokens``; for Responses it becomes
+            ``max_output_tokens``.
+        temperature: Sampling temperature. Ignored when using Responses API.
+        logit_bias: Optional logit bias dict (only supported in Chat Completions).
+        stream: Whether to request a streaming response.
+
+    Returns:
+        The raw response object returned by the underlying API.
+    """
+
+    if not config.USE_RESPONSES_API:
+        converted: List[Dict[str, Any]] = []
+        for msg in messages:
+            role = msg.get("role")
+            if role == "developer":
+                msg = dict(msg, role="system")
+            converted.append(msg)
+
+        params: Dict[str, Any] = {
+            "model": model,
+            "messages": converted,
+            "stream": stream,
+        }
+        if temperature is not None:
+            params["temperature"] = temperature
+        if max_tokens is not None:
+            params["max_completion_tokens"] = max_tokens
+        if logit_bias:
+            params["logit_bias"] = logit_bias
+        return await llm_client.chat.completions.create(**params)
+
+    # Responses API path
+    input_messages: List[Dict[str, Any]] = []
+    for msg in messages:
+        role = msg.get("role")
+        if role in {"system", "developer"}:
+            role = "developer"
+        clean_msg = {k: v for k, v in msg.items() if k != "name"}
+        clean_msg["role"] = role
+        input_messages.append(clean_msg)
+
+    params = {
+        "model": model,
+        "input": input_messages if input_messages else "",
+        "stream": stream,
+    }
+    if max_tokens is not None:
+        params["max_output_tokens"] = max_tokens
+    # Some Responses models do not support temperature; omit to avoid errors
+
+    return await llm_client.responses.create(**params)
+
+
+def extract_text(response: Any) -> str:
+    """Extract the assistant text from a response object."""
+    if not config.USE_RESPONSES_API:
+        try:
+            return (
+                response.choices[0].message.content.strip()
+            )
+        except Exception:
+            return ""
+
+    # Responses API
+    parts: List[str] = []
+    for item in getattr(response, "output", []) or []:
+        for content in getattr(item, "content", []) or []:
+            text = getattr(content, "text", "")
+            if text:
+                parts.append(text)
+    return "".join(parts).strip()

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -15,6 +15,7 @@ from config import config
 from common_models import MsgNode
 from logit_biases import LOGIT_BIAS_UNWANTED_TOKENS_STR
 from utils import append_absolute_dates
+from openai_api import create_chat_completion, extract_text
 
 
 logger = logging.getLogger(__name__)
@@ -268,21 +269,21 @@ Do not include any explanations or conversational text outside the JSON object.
         if getattr(config, "LLM_SUPPORTS_JSON_MODE", False):
              response_format_arg = {"response_format": {"type": "json_object"}}
 
-        response = await llm_client.chat.completions.create(
-            model=config.FAST_LLM_MODEL,
-            messages=[
+        response = await create_chat_completion(
+            llm_client,
+            [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
             ],
-            max_tokens=8192,  # Increased max_tokens for potentially larger JSON outputs
+            model=config.FAST_LLM_MODEL,
+            max_tokens=8192,
             temperature=0.2,
-            stream=False,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
-            **response_format_arg
+            **response_format_arg,
         )
 
-        if response.choices and response.choices[0].message and response.choices[0].message.content:
-            raw_content = response.choices[0].message.content.strip()
+        raw_content = extract_text(response)
+        if raw_content:
 
             if raw_content.startswith("```json"):
                 raw_content = raw_content[7:]
@@ -311,21 +312,23 @@ Do not include any explanations or conversational text outside the JSON object.
             return extracted_data
     except Exception as e:
         if "response_format" in str(e) and response_format_arg:
-            logger.warning(f"extract_structured_data_llm: Failed with response_format, retrying without it for {source_doc_id}. Error: {e}")
+            logger.warning(
+                f"extract_structured_data_llm: Failed with response_format, retrying without it for {source_doc_id}. Error: {e}"
+            )
             try:
-                response = await llm_client.chat.completions.create(
-                    model=config.FAST_LLM_MODEL,
-                    messages=[
+                response = await create_chat_completion(
+                    llm_client,
+                    [
                         {"role": "system", "content": system_prompt},
                         {"role": "user", "content": user_prompt}
                     ],
+                    model=config.FAST_LLM_MODEL,
                     max_tokens=2048,
                     temperature=0.2,
-                    stream=False,
                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                 )
-                if response.choices and response.choices[0].message and response.choices[0].message.content:
-                    raw_content = response.choices[0].message.content.strip()
+                raw_content = extract_text(response)
+                if raw_content:
                     if raw_content.startswith("```json"):
                         raw_content = raw_content[7:]
                         if raw_content.endswith("```"):
@@ -333,11 +336,15 @@ Do not include any explanations or conversational text outside the JSON object.
                         raw_content = raw_content.strip()
                     extracted_data = _parse_json_with_recovery(raw_content)
                     if extracted_data is None:
-                        logger.error(f"extract_structured_data_llm (retry): Failed to decode JSON from LLM response for {source_doc_id}. Content: {raw_content[:500]}")
+                        logger.error(
+                            f"extract_structured_data_llm (retry): Failed to decode JSON from LLM response for {source_doc_id}. Content: {raw_content[:500]}"
+                        )
                         return None
-                    if not isinstance(extracted_data, dict) or  \
+                    if not isinstance(extracted_data, dict) or \
                        not all(key in extracted_data for key in ["entities", "relations", "observations"]):
-                        logger.warning(f"extract_structured_data_llm (retry): LLM response for {source_doc_id} was not the expected dict structure. Content: {raw_content[:500]}")
+                        logger.warning(
+                            f"extract_structured_data_llm (retry): LLM response for {source_doc_id} was not the expected dict structure. Content: {raw_content[:500]}"
+                        )
                         return None
                     logger.info(f"Successfully extracted structured data (on retry) for {source_doc_id}.")
                     return extracted_data
@@ -371,19 +378,19 @@ async def distill_conversation_to_sentence_llm(llm_client: Any, text_to_distill:
     )
     try:
         logger.debug(f"Requesting distillation from model {config.FAST_LLM_MODEL} for focused exchange.")
-        response = await llm_client.chat.completions.create(
-            model=config.FAST_LLM_MODEL,
-            messages=[
+        response = await create_chat_completion(
+            llm_client,
+            [
                 {"role": "system", "content": "You are an expert contextual knowledge distiller focusing on user-assistant turn pairs."},
                 {"role": "user", "content": prompt}
             ],
+            model=config.FAST_LLM_MODEL,
             max_tokens=2048,
             temperature=0.5,
-            stream=False,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        if response.choices and response.choices[0].message and response.choices[0].message.content:
-            distilled = response.choices[0].message.content.strip()
+        distilled = extract_text(response)
+        if distilled:
             logger.info(f"Distilled exchange to sentence(s): '{distilled[:100]}...'")
             return distilled
         logger.warning("LLM distillation (focused exchange) returned no content.")
@@ -425,19 +432,19 @@ async def synthesize_retrieved_contexts_llm(llm_client: Any, retrieved_contexts:
     )
     try:
         logger.debug(f"Requesting context synthesis from model {config.FAST_LLM_MODEL}.")
-        response = await llm_client.chat.completions.create(
-            model=config.LLM_MODEL,
-            messages=[
+        response = await create_chat_completion(
+            llm_client,
+            [
                 {"role": "system", "content": "You are an expert context synthesizer."},
                 {"role": "user", "content": prompt}
             ],
+            model=config.LLM_MODEL,
             max_tokens=3072,
             temperature=0.6,
-            stream=False,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        if response.choices and response.choices[0].message and response.choices[0].message.content:
-            synthesized_context = response.choices[0].message.content.strip()
+        synthesized_context = extract_text(response)
+        if synthesized_context:
             logger.info(f"Synthesized RAG context: '{synthesized_context[:150]}...'")
             return synthesized_context
         logger.warning("LLM context synthesis returned no content.")
@@ -472,19 +479,20 @@ async def merge_memory_snippet_with_summary_llm(
     )
 
     try:
-        response = await llm_client.chat.completions.create(
-            model=config.FAST_LLM_MODEL,
-            messages=[
+        response = await create_chat_completion(
+            llm_client,
+            [
                 {"role": "system", "content": "You are a memory consolidation assistant."},
                 {"role": "user", "content": user_text},
             ],
+            model=config.FAST_LLM_MODEL,
             max_tokens=2048,
             temperature=0.4,
-            stream=False,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        if response.choices and response.choices[0].message and response.choices[0].message.content:
-            return response.choices[0].message.content.strip()
+        merged = extract_text(response)
+        if merged:
+            return merged
         logger.warning("merge_memory_snippet_with_summary_llm: LLM returned no content.")
         return None
     except Exception as e:


### PR DESCRIPTION
## Summary
- add openai_api helper to switch between legacy chat completions and new responses API
- wire modules to use helper and support streaming responses events
- document USE_RESPONSES_API toggle in config and example.env
- strip unsupported parameters when using the Responses API
- send max_completion_tokens when calling Chat Completions models to avoid parameter errors
- map system messages to developer role for Responses API and back to system for Chat Completions
- retry without streaming when Responses API models reject the `stream` parameter and fall back to non-streaming output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689500a823288328b5ada2e0f5a52d6b