### PR TITLE
Enable logit bias for responses API

### DIFF
--- a/openai_api.py
+++ b/openai_api.py
@@ -29,7 +29,7 @@ async def create_chat_completion(
             is sent as ``max_completion_tokens``; for Responses it becomes
             ``max_output_tokens``.
         temperature: Sampling temperature. Ignored when using Responses API.
-        logit_bias: Optional logit bias dict (only supported in Chat Completions).
+        logit_bias: Optional logit bias dict.
         stream: Whether to request a streaming response.
 
     Returns:
@@ -76,7 +76,11 @@ async def create_chat_completion(
         params["max_output_tokens"] = max_tokens
     # Some Responses models do not support temperature; omit to avoid errors
 
-    return await llm_client.responses.create(**params)
+    extra_body: Optional[Dict[str, Dict[str, int]]] = None
+    if logit_bias:
+        extra_body = {"logit_bias": logit_bias}
+
+    return await llm_client.responses.create(**params, extra_body=extra_body)
 
 
 def extract_text(response: Any) -> str:

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -1,0 +1,38 @@
+"""Tests for openai_api module."""
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from openai_api import create_chat_completion
+
+
+class DummyResponses:
+    def __init__(self):
+        self.called_with = None
+
+    async def create(self, **kwargs):
+        self.called_with = kwargs
+        return SimpleNamespace()
+
+
+class DummyClient:
+    def __init__(self):
+        self.responses = DummyResponses()
+
+
+def test_logit_bias_passed_in_responses(monkeypatch):
+    """logit_bias should be sent via extra_body when using Responses API."""
+    from config import config
+
+    monkeypatch.setattr(config, "USE_RESPONSES_API", True)
+    client = DummyClient()
+    logit_bias = {"123": -1}
+    asyncio.run(
+        create_chat_completion(client, [], model="gpt-4o", logit_bias=logit_bias)
+    )
+    assert client.responses.called_with["extra_body"]["logit_bias"] == logit_bias


### PR DESCRIPTION
## Summary
- pass logit bias via `extra_body` when using the OpenAI Responses API
- test that logit bias propagates to responses client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952c6e89e48328af3e9dd0fac63306