### PR TITLE
Support logit bias with Responses API

### DIFF
--- a/openai_api.py
+++ b/openai_api.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Sequence
+import logging
 
 from config import config
+
+logger = logging.getLogger(__name__)
 
 
 async def create_chat_completion(
@@ -28,8 +31,8 @@ async def create_chat_completion(
         max_tokens: Maximum tokens for the response. For Chat Completions this
             is sent as ``max_completion_tokens``; for Responses it becomes
             ``max_output_tokens``.
-        temperature: Sampling temperature. Ignored when using Responses API.
-        logit_bias: Optional logit bias dict (only supported in Chat Completions).
+        temperature: Sampling temperature. Some Responses models may not support it.
+        logit_bias: Optional logit bias dict applied to both APIs.
         stream: Whether to request a streaming response.
 
     Returns:
@@ -74,9 +77,17 @@ async def create_chat_completion(
     }
     if max_tokens is not None:
         params["max_output_tokens"] = max_tokens
-    # Some Responses models do not support temperature; omit to avoid errors
 
-    return await llm_client.responses.create(**params)
+    extra_body: Dict[str, Any] = {}
+    if logit_bias:
+        # The Responses API expects logit_bias as a top-level field, but the
+        # typed client does not expose it yet. Pass it through via extra_body.
+        extra_body["logit_bias"] = logit_bias
+
+    return await llm_client.responses.create(
+        **params,
+        extra_body=extra_body or None,
+    )
 
 
 def extract_text(response: Any) -> str:

--- a/tests/test_openai_api.py
+++ b/tests/test_openai_api.py
@@ -1,0 +1,43 @@
+"""Tests for openai_api module."""
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from openai_api import create_chat_completion
+
+
+class DummyResponses:
+    def __init__(self):
+        self.called_with = None
+
+    async def create(self, **kwargs):
+        self.called_with = kwargs
+        return SimpleNamespace()
+
+
+class DummyClient:
+    def __init__(self):
+        self.responses = DummyResponses()
+
+
+def test_logit_bias_passed_to_responses(monkeypatch):
+    """logit_bias should be forwarded to the Responses client via extra_body."""
+    from config import config
+
+    monkeypatch.setattr(config, "USE_RESPONSES_API", True)
+    client = DummyClient()
+    logit_bias = {"123": -1}
+
+    asyncio.run(
+        create_chat_completion(client, [], model="gpt-4o", logit_bias=logit_bias)
+    )
+
+    assert "extra_body" in client.responses.called_with
+    extra = client.responses.called_with["extra_body"]
+    assert extra["logit_bias"] == logit_bias
+    assert "text" not in extra


### PR DESCRIPTION
## Summary
- pass `logit_bias` through to Responses API requests as a top-level field via `extra_body`
- test that `logit_bias` is forwarded without a nested `text` wrapper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68952c6e89e48328af3e9dd0fac63306