### PR TITLE
feat: add responses api tuning options

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,9 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `LLM_SUPPORTS_JSON_MODE` (Default: `false`): Set to `true` if your LLM server and the selected model support JSON mode for structured output (e.g., for entity extraction).
 *   `USE_RESPONSES_API` (Default: `false`): When `true`, use OpenAI's Responses API instead of legacy Chat Completions. System prompts are passed via the `instructions` field and model names may require the orchestrator variant (e.g., `gpt-4o`).
 *   `LLM_STREAMING` (Default: `false`): Stream token-by-token responses when `true`. Some models require organization verification to enable streaming.
+*   `RESPONSES_REASONING_EFFORT` (Default: `medium`): Controls the reasoning effort for Responses models. Options are `minimal`, `low`, `medium`, or `high`.
+*   `RESPONSES_VERBOSITY` (Default: `medium`): Sets the verbosity of Responses output. Options are `low`, `medium`, or `high`.
+*   `RESPONSES_SERVICE_TIER` (Default: `auto`): Selects the service tier for Responses requests. Options are `auto`, `default`, `flex`, or `priority`.
 *   `MAX_MESSAGE_HISTORY` (Default: `10`): The maximum number of recent messages (user and assistant turns) to include in the short-term context sent to the LLM.
 *   `MAX_COMPLETION_TOKENS` (Default: `2048`): The maximum number of tokens the LLM is allowed to generate in a single response.
 

--- a/config.py
+++ b/config.py
@@ -38,6 +38,15 @@ class Config:
             logger.warning("Invalid value for %s=%s; using %s", env_var, value, default)
             return default
 
+        def _get_choice(env_var: str, choices: set[str], default: str) -> str:
+            value = os.getenv(env_var, default)
+            if value not in choices:
+                logger.warning(
+                    "Invalid value for %s=%s; using %s", env_var, value, default
+                )
+                return default
+            return value
+
         def _parse_int_list(env_var: str) -> list[int]:
             parts = os.getenv(env_var, "").split(",")
             values: list[int] = []
@@ -62,6 +71,21 @@ class Config:
         self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False) # New Flag
         self.USE_RESPONSES_API = _get_bool("USE_RESPONSES_API", False)
         self.LLM_STREAMING = _get_bool("LLM_STREAMING", False)
+        self.RESPONSES_REASONING_EFFORT = _get_choice(
+            "RESPONSES_REASONING_EFFORT",
+            {"minimal", "low", "medium", "high"},
+            "medium",
+        )
+        self.RESPONSES_VERBOSITY = _get_choice(
+            "RESPONSES_VERBOSITY",
+            {"low", "medium", "high"},
+            "medium",
+        )
+        self.RESPONSES_SERVICE_TIER = _get_choice(
+            "RESPONSES_SERVICE_TIER",
+            {"auto", "default", "flex", "priority"},
+            "auto",
+        )
         self.SYSTEM_PROMPT_FILE = os.getenv("SYSTEM_PROMPT_FILE", "system_prompt.md")
 
         self.ALLOWED_CHANNEL_IDS = _parse_int_list("ALLOWED_CHANNEL_IDS")

--- a/example.env
+++ b/example.env
@@ -8,6 +8,9 @@ LLM_API_KEY =
 LLM_SUPPORTS_JSON_MODE = true
 USE_RESPONSES_API = false
 LLM_STREAMING = false # stream token-by-token responses (requires org verification)
+RESPONSES_REASONING_EFFORT = medium
+RESPONSES_VERBOSITY = medium
+RESPONSES_SERVICE_TIER = auto
 
 SYSTEM_PROMPT_FILE = system_prompt.md
 

--- a/openai_api.py
+++ b/openai_api.py
@@ -74,6 +74,12 @@ async def create_chat_completion(
     }
     if max_tokens is not None:
         params["max_output_tokens"] = max_tokens
+    if config.RESPONSES_REASONING_EFFORT:
+        params["reasoning"] = {"effort": config.RESPONSES_REASONING_EFFORT}
+    if config.RESPONSES_VERBOSITY:
+        params["verbosity"] = config.RESPONSES_VERBOSITY
+    if config.RESPONSES_SERVICE_TIER:
+        params["service_tier"] = config.RESPONSES_SERVICE_TIER
     # Some Responses models do not support temperature; omit to avoid errors
 
     return await llm_client.responses.create(**params)


### PR DESCRIPTION
## Summary
- allow configuring reasoning effort, verbosity, and service tier for the Responses API via environment variables
- send these parameters in Requests to the OpenAI Responses API when enabled
- document new settings in `README.md` and `example.env`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689558cd65a08328af7b2e8f70a268a3