### PR TITLE
fix: use Responses content types for image prompts

### DIFF
--- a/openai_api.py
+++ b/openai_api.py
@@ -65,6 +65,21 @@ async def create_chat_completion(
             role = "developer"
         clean_msg = {k: v for k, v in msg.items() if k != "name"}
         clean_msg["role"] = role
+
+        content = clean_msg.get("content")
+        if isinstance(content, list):
+            # Convert legacy Chat Completions content types to Responses API types
+            for item in content:
+                if isinstance(item, dict):
+                    ctype = item.get("type")
+                    if ctype == "text":
+                        item["type"] = "input_text"
+                    elif ctype == "image_url":
+                        item["type"] = "input_image"
+        elif isinstance(content, str):
+            # Allow simple string content by wrapping it in an ``input_text`` part
+            clean_msg["content"] = [{"type": "input_text", "text": content}]
+
         input_messages.append(clean_msg)
 
     params = {


### PR DESCRIPTION
## Summary
- Convert legacy `text` and `image_url` content types to `input_text` and `input_image` when using OpenAI's Responses API
- Support plain string content by wrapping it in `input_text`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68956a2a9c1c8328b28195a80ddb909d