### PR TITLE
Restore streaming for Chat Completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `VISION_LLM_MODEL` (Default: `llava`): The model used for tasks involving image understanding (e.g., the `/ap` command or describing screenshots).
 *   `LLM_SUPPORTS_JSON_MODE` (Default: `false`): Set to `true` if your LLM server and the selected model support JSON mode for structured output (e.g., for entity extraction).
 *   `USE_RESPONSES_API` (Default: `false`): When `true`, use OpenAI's Responses API instead of legacy Chat Completions. System prompts are passed via the `instructions` field and model names may require the orchestrator variant (e.g., `gpt-4o`).
-*   `LLM_STREAMING` (Default: `false`): Stream token-by-token responses when `true`. Some models require organization verification to enable streaming.
+*   `LLM_STREAMING` (Default: `true` for Chat Completions; automatically disabled when `USE_RESPONSES_API` is `true`): Stream token-by-token responses when enabled. Some models require organization verification to enable streaming.
 *   `MAX_MESSAGE_HISTORY` (Default: `10`): The maximum number of recent messages (user and assistant turns) to include in the short-term context sent to the LLM.
 *   `MAX_COMPLETION_TOKENS` (Default: `2048`): The maximum number of tokens the LLM is allowed to generate in a single response.
 

--- a/config.py
+++ b/config.py
@@ -61,7 +61,10 @@ class Config:
         self.LLM_API_KEY = os.getenv("LLM_API_KEY", "")
         self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False) # New Flag
         self.USE_RESPONSES_API = _get_bool("USE_RESPONSES_API", False)
-        self.LLM_STREAMING = _get_bool("LLM_STREAMING", False)
+        # Stream token-by-token responses by default unless the Responses API is in use
+        self.LLM_STREAMING = _get_bool(
+            "LLM_STREAMING", not self.USE_RESPONSES_API
+        )
         self.SYSTEM_PROMPT_FILE = os.getenv("SYSTEM_PROMPT_FILE", "system_prompt.md")
 
         self.ALLOWED_CHANNEL_IDS = _parse_int_list("ALLOWED_CHANNEL_IDS")

--- a/example.env
+++ b/example.env
@@ -7,7 +7,7 @@ MISTRAL_API_KEY =
 LLM_API_KEY =
 LLM_SUPPORTS_JSON_MODE = true
 USE_RESPONSES_API = false
-LLM_STREAMING = false # stream token-by-token responses (requires org verification)
+LLM_STREAMING = true # stream token-by-token responses (auto-disabled with USE_RESPONSES_API; requires org verification)
 
 SYSTEM_PROMPT_FILE = system_prompt.md
 


### PR DESCRIPTION
## Summary
- Re-enable streaming for Chat Completions when replying in Discord
- Automatically disable streaming when using the Responses API
- Update configuration defaults and documentation to reflect streaming behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68956b6a82548328928e93424e39d5de