### PR TITLE
I've fixed the vision API calls to use the correct content types.

### DIFF
--- a/discord_commands.py
+++ b/discord_commands.py
@@ -625,8 +625,8 @@ async def describe_image(image_url: str) -> Optional[str]:
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "Describe this image for a visually impaired user. Be concise and focus on the most important elements."},
-                    {"type": "image_url", "image_url": {"url": image_url_for_llm}}
+                    {"type": "input_text", "text": "Describe this image for a visually impaired user. Be concise and focus on the most important elements."},
+                    {"type": "input_image", "image_url": {"url": image_url_for_llm}}
                 ]
             }
         ]
@@ -2709,8 +2709,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             )
 
             user_content_for_ap_node = [
-                {"type": "text", "text": user_prompt if user_prompt else "Describe this image with the AP Photo celebrity twist."},
-                {"type": "image_url", "image_url": {"url": image_url_for_llm}}
+                {"type": "input_text", "text": user_prompt if user_prompt else "Describe this image with the AP Photo celebrity twist."},
+                {"type": "input_image", "image_url": {"url": image_url_for_llm}}
             ]
             user_msg_node = MsgNode("user", user_content_for_ap_node, name=str(interaction.user.id))
 

--- a/discord_events.py
+++ b/discord_events.py
@@ -250,7 +250,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
 
         current_message_content_parts.append(
             {
-                "type": "text",
+                "type": "input_text",
                 "text": user_message_text_for_processing
                 if user_message_text_for_processing
                 else "",
@@ -268,34 +268,34 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                         if len(img_bytes) > config.MAX_IMAGE_BYTES_FOR_PROMPT:
                             logger.warning(f"Image {attachment.filename} from {message.author.name} is too large ({len(img_bytes)} bytes). Skipping.")
                             for part in current_message_content_parts:
-                                if part["type"] == "text":
+                                if part["type"] == "input_text":
                                     part["text"] += f" [Note: Attached image '{attachment.filename}' was too large to process.]"
                                     break
                             continue
 
                         b64_img = base64.b64encode(img_bytes).decode('utf-8')
-                        current_message_content_parts.append({"type": "image_url", "image_url": {"url": f"data:{attachment.content_type};base64,{b64_img}"}})
+                        current_message_content_parts.append({"type": "input_image", "image_url": {"url": f"data:{attachment.content_type};base64,{b64_img}"}})
                         image_added_to_prompt = True; images_processed_count +=1
                         logger.info(f"Added image '{attachment.filename}' to prompt for message from {message.author.name}.")
                     except Exception as e:
                         logger.error(f"Error processing image attachment '{attachment.filename}': {e}", exc_info=True)
 
-        text_part_exists_with_content = any(p["type"] == "text" and p.get("text","").strip() for p in current_message_content_parts)
+        text_part_exists_with_content = any(p["type"] == "input_text" and p.get("text","").strip() for p in current_message_content_parts)
         if image_added_to_prompt and not text_part_exists_with_content:
              # ... (image text part handling remains the same)
             text_part_updated = False
             for part in current_message_content_parts:
-                if part["type"] == "text":
+                if part["type"] == "input_text":
                     part["text"] = "User sent image(s). Please describe or respond based on the image(s)."
                     text_part_updated = True
                     break
             if not text_part_updated:
-                 current_message_content_parts.insert(0, {"type": "text", "text": "User sent image(s). Please describe or respond based on the image(s)."})
+                 current_message_content_parts.insert(0, {"type": "input_text", "text": "User sent image(s). Please describe or respond based on the image(s)."})
 
 
         current_text_for_url_detection = ""
         for part in current_message_content_parts:
-            if part["type"] == "text":
+            if part["type"] == "input_text":
                 current_text_for_url_detection = part["text"];
                 break
 
@@ -400,13 +400,13 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         # as we are using their descriptions instead.
         text_part_found_and_updated = False
         for part_idx, part_dict in enumerate(current_message_content_parts):
-            if part_dict["type"] == "text":
+            if part_dict["type"] == "input_text":
                 current_message_content_parts[part_idx]["text"] = final_user_message_text_for_llm
                 text_part_found_and_updated = True
                 break
         if not text_part_found_and_updated: # Should ideally not happen if initialized correctly
             logger.error("Critical: Text part missing in current_message_content_parts before LLM call after URL processing.")
-            current_message_content_parts.insert(0, {"type": "text", "text": final_user_message_text_for_llm})
+            current_message_content_parts.insert(0, {"type": "input_text", "text": final_user_message_text_for_llm})
 
         # The rest of the logic determining user_msg_node_content_final based on current_message_content_parts
         # will now correctly use the text that includes scraped content and image descriptions.
@@ -417,9 +417,9 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         has_image_content = False
 
         for part in current_message_content_parts:
-            if part.get("type") == "text" and str(part.get("text","")).strip():
+            if part.get("type") == "input_text" and str(part.get("text","")).strip():
                 has_text_content = True
-            if part.get("type") == "image_url":
+            if part.get("type") == "input_image":
                 has_image_content = True
 
         if has_text_content or has_image_content:
@@ -429,7 +429,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
             logger.info(f"Ignoring message from {message.author.name} as it resulted in no processable content after all stages."); return
 
         user_msg_node_content_final: Union[str, List[dict]]
-        if len(current_message_content_parts) == 1 and current_message_content_parts[0]["type"] == "text" and not has_image_content:
+        if len(current_message_content_parts) == 1 and current_message_content_parts[0]["type"] == "input_text" and not has_image_content:
             user_msg_node_content_final = current_message_content_parts[0]["text"]
         else:
             user_msg_node_content_final = current_message_content_parts

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -294,7 +294,7 @@ async def _stream_llm_handler(
         for p_node in final_prompt_for_llm_call:
             if isinstance(p_node.content, list):
                 for content_item in p_node.content:
-                    if isinstance(content_item, dict) and content_item.get("type") == "image_url":
+                    if isinstance(content_item, dict) and content_item.get("type") == "input_image":
                         is_vision_request = True
                         break
             if is_vision_request:
@@ -766,9 +766,9 @@ async def get_description_for_image(llm_client: Any, image_path: str) -> str:
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "Describe this screenshot of a webpage. Focus on the visible text, layout, and any interactive elements. What information is presented here? Provide a concise summary."},
+                    {"type": "input_text", "text": "Describe this screenshot of a webpage. Focus on the visible text, layout, and any interactive elements. What information is presented here? Provide a concise summary."},
                     {
-                        "type": "image_url",
+                        "type": "input_image",
                         "image_url": {"url": f"data:image/png;base64,{b64_image}"},
                     },
                 ],

--- a/llm_request_processor.py
+++ b/llm_request_processor.py
@@ -312,8 +312,8 @@ async def llm_request_processor_task(bot_state: BotState, llm_client: Any, bot_i
                             image_url_for_llm = f"data:{ap_data.image_content_type};base64,{ap_data.image_b64}"
 
                             user_content_for_ap_node_list = [
-                                {"type": "text", "text": ap_data.user_prompt_text},
-                                {"type": "image_url", "image_url": {"url": image_url_for_llm}}
+                                {"type": "input_text", "text": ap_data.user_prompt_text},
+                                {"type": "input_image", "image_url": {"url": image_url_for_llm}}
                             ]
                             user_msg_node_ap = MsgNode("user", user_content_for_ap_node_list, name=ap_data.base_user_id_for_node)
 


### PR DESCRIPTION
I saw that the OpenAI API for vision requests was updated to require 'input_text' and 'input_image' as the types for content parts in a message. Your codebase was using the outdated 'text' and 'image_url' types, which was causing an `openai.BadRequestError` (400).

To address this, I:
- Replaced all occurrences of `{"type": "text", ...}` with `{"type": "input_text", ...}` in multipart message construction.
- Replaced all occurrences of `{"type": "image_url", ...}` with `{"type": "input_image", ...}`.
- Updated the logic that detects vision requests to check for the new `input_image` type.

I modified the following files:
- `llm_handling.py`
- `discord_events.py`
- `discord_commands.py`
- `llm_request_processor.py`

I've updated all instances and verified the fix by searching the codebase to ensure no outdated types remain.