### PR TITLE
feat: Add environment variables for LLM API selection

### DIFF
--- a/config.py
+++ b/config.py
@@ -74,8 +74,9 @@ class Config:
         self.VISION_LLM_MODEL = os.getenv("VISION_LLM_MODEL", "llava")
         self.FAST_LLM_MODEL = os.getenv("FAST_LLM_MODEL", self.LLM_MODEL)
         self.LLM_API_KEY = os.getenv("LLM_API_KEY", "")
-        self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False) # New Flag
-        self.USE_RESPONSES_API = _get_bool("USE_RESPONSES_API", False)
+        self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False)
+        self.LLM_USE_RESPONSES_API = _get_bool("LLM_USE_RESPONSES_API", False)
+        self.FAST_LLM_USE_RESPONSES_API = _get_bool("FAST_LLM_USE_RESPONSES_API", False)
         self.LLM_STREAMING = _get_bool("LLM_STREAMING", True)
         self.RESPONSES_REASONING_EFFORT = _get_choice(
             "RESPONSES_REASONING_EFFORT",

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -228,11 +228,12 @@ async def process_rss_feed(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url=feed_url,
@@ -354,11 +355,12 @@ async def process_ground_news(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url="ground_news_my",
@@ -508,11 +510,12 @@ async def process_ground_news_topic(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url=f"ground_news_topic_{topic_slug}",
@@ -635,11 +638,12 @@ async def describe_image(image_url: str) -> Optional[str]:
             llm_client_instance,
             prompt_messages,
             model=config.VISION_LLM_MODEL,
+            use_responses_api=config.LLM_USE_RESPONSES_API,
             max_tokens=250,
             temperature=0.3,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        description = extract_text(response)
+        description = extract_text(response, config.LLM_USE_RESPONSES_API)
         if description:
             return description
         return None
@@ -1060,11 +1064,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                             {"role": "user", "content": summarization_prompt}
                         ],
                         model=config.FAST_LLM_MODEL,
+                        use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                         max_tokens=1024,
                         temperature=0.3,
                         logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                     )
-                    article_summary = extract_text(summary_response)
+                    article_summary = extract_text(summary_response, config.FAST_LLM_USE_RESPONSES_API)
                     if article_summary:
                         logger.info(f"Summarized '{article_title}': {article_summary[:100]}...")
                         article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
@@ -1415,11 +1420,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                             {"role": "user", "content": summarization_prompt_search}
                         ],
                         model=config.FAST_LLM_MODEL,
+                        use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                         max_tokens=1024,
                         temperature=0.3,
                         logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                     )
-                    page_summary = extract_text(summary_response_search)
+                    page_summary = extract_text(summary_response_search, config.FAST_LLM_USE_RESPONSES_API)
                     if page_summary:
                         logger.info(f"Summarized '{page_title}' for search query '{query}': {page_summary[:100]}...")
                         page_summaries_for_final_synthesis.append(f"Source Page: {page_title} ({page_url})\nSummary of Page Content: {page_summary}\n\n")
@@ -1750,11 +1756,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                                 {"role": "user", "content": prompt}
                             ],
                             model=config.FAST_LLM_MODEL,
+                            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                             max_tokens=1024,
                             temperature=0.5,
                             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                         )
-                        summary = extract_text(response)
+                        summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
                         if summary and summary != "[LLM summarization failed]":
                             store_rss_summary(
                                 feed_url=ent["feed_url"],

--- a/example.env
+++ b/example.env
@@ -6,7 +6,8 @@ MISTRAL_API_KEY =
 
 LLM_API_KEY =
 LLM_SUPPORTS_JSON_MODE = true
-USE_RESPONSES_API = false
+LLM_USE_RESPONSES_API = false
+FAST_LLM_USE_RESPONSES_API = false
 LLM_STREAMING = false # stream token-by-token responses (requires org verification)
 # RESPONSES_REASONING_EFFORT = medium
 # RESPONSES_VERBOSITY = medium

--- a/llm_handling.py
+++ b/llm_handling.py
@@ -164,26 +164,28 @@ async def get_simplified_llm_stream(
     llm_client: Any,
     prompt_messages: List[MsgNode],
     is_vision_request: bool
-) -> Tuple[Optional[Any], List[MsgNode]]:
+) -> Tuple[Optional[Any], List[MsgNode], bool]:
     if not prompt_messages:
         raise ValueError("Prompt messages cannot be empty for get_simplified_llm_stream.")
 
     logger.info(f"Requesting final response. Vision request: {is_vision_request}")
 
     final_stream_model = config.VISION_LLM_MODEL if is_vision_request else config.LLM_MODEL
-    logger.info(f"Using model for final response: {final_stream_model}")
+    use_responses_api = config.LLM_USE_RESPONSES_API
+    logger.info(f"Using model for final response: {final_stream_model} (Responses API: {use_responses_api})")
     api_messages = [msg_node.to_dict() for msg_node in prompt_messages]
     try:
         final_llm_stream = await create_chat_completion(
             llm_client,
             api_messages,
             model=final_stream_model,
+            use_responses_api=use_responses_api,
             max_tokens=config.MAX_COMPLETION_TOKENS,
             temperature=0.7,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             stream=config.LLM_STREAMING,
         )
-        return final_llm_stream, prompt_messages
+        return final_llm_stream, prompt_messages, use_responses_api
     except BadRequestError as e:
         err_param = (getattr(e, "body", {}) or {}).get("error", {}).get("param")
         if config.LLM_STREAMING and err_param == "stream":
@@ -195,12 +197,13 @@ async def get_simplified_llm_stream(
                     llm_client,
                     api_messages,
                     model=final_stream_model,
+                    use_responses_api=use_responses_api,
                     max_tokens=config.MAX_COMPLETION_TOKENS,
                     temperature=0.7,
                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                     stream=False,
                 )
-                return final_response, prompt_messages
+                return final_response, prompt_messages, use_responses_api
             except Exception as inner_e:
                 e = inner_e
         logger.error(
@@ -222,7 +225,7 @@ async def get_simplified_llm_stream(
             )
     except Exception as log_e:
         logger.error(f"Error during logging of problematic messages: {log_e}")
-    return None, prompt_messages
+    return None, prompt_messages, False
 
 async def _stream_llm_handler(
     interaction_or_message: Union[discord.Interaction, discord.Message],
@@ -301,7 +304,7 @@ async def _stream_llm_handler(
                 break
         logger.info(f"Determined is_vision_request for '{title}': {is_vision_request}")
 
-        stream, final_prompt_used_by_llm = await get_simplified_llm_stream(
+        stream, final_prompt_used_by_llm, use_responses_api = await get_simplified_llm_stream(
             llm_client, final_prompt_for_llm_call, is_vision_request
         )
         final_prompt_for_rag = final_prompt_used_by_llm
@@ -345,7 +348,7 @@ async def _stream_llm_handler(
 
             async for chunk_data in stream:
                 delta_content = ""
-                if config.USE_RESPONSES_API:
+                if use_responses_api:
                     event_type = getattr(chunk_data, "type", "")
                     if event_type == "response.output_text.delta":
                         delta_content = getattr(chunk_data, "delta", "") or ""
@@ -409,7 +412,7 @@ async def _stream_llm_handler(
                         sent_messages.append(await channel.send(embed=embed))
                 await asyncio.sleep(config.STREAM_EDIT_THROTTLE_SECONDS)
         else:
-            full_response_content = extract_text(stream)
+            full_response_content = extract_text(stream, use_responses_api)
 
 
         final_display_text = response_prefix + full_response_content
@@ -776,10 +779,12 @@ async def get_description_for_image(llm_client: Any, image_path: str) -> str:
         ]
 
         logger.debug(f"Sending image description request to model: {config.VISION_LLM_MODEL}")
+        use_responses_api = config.LLM_USE_RESPONSES_API
         response = await create_chat_completion(
             llm_client,
             prompt_messages,
             model=config.VISION_LLM_MODEL,
+            use_responses_api=use_responses_api,
             max_tokens=(
                 config.MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION
                 if hasattr(config, "MAX_COMPLETION_TOKENS_IMAGE_DESCRIPTION")

--- a/llm_request_processor.py
+++ b/llm_request_processor.py
@@ -153,11 +153,12 @@ async def llm_request_processor_task(bot_state: BotState, llm_client: Any, bot_i
                                         {"role": "user", "content": summarization_prompt}
                                     ],
                                     model=config.FAST_LLM_MODEL,
+                                    use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                                     max_tokens=250,
                                     temperature=0.3,
                                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                                 )
-                                article_summary = extract_text(summary_response)
+                                article_summary = extract_text(summary_response, config.FAST_LLM_USE_RESPONSES_API)
                                 if article_summary:
                                     article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
                                     store_news_summary(topic=topic, url=article_url, summary_text=article_summary) # Assuming this is thread-safe or handled

--- a/openai_api.py
+++ b/openai_api.py
@@ -15,6 +15,7 @@ async def create_chat_completion(
     llm_client: Any,
     messages: Sequence[Dict[str, Any]],
     model: str,
+    use_responses_api: bool,
     max_tokens: Optional[int] = None,
     temperature: Optional[float] = None,
     logit_bias: Optional[Dict[str, int]] = None,
@@ -29,6 +30,7 @@ async def create_chat_completion(
             In Chat Completions they are converted to ``system`` messages; in
             Responses they remain ``developer`` messages.
         model: Model name to use.
+        use_responses_api: If True, use the Responses API format.
         max_tokens: Maximum tokens for the response. For Chat Completions this
             is sent as ``max_completion_tokens``; for Responses it becomes
             ``max_output_tokens``.
@@ -39,8 +41,7 @@ async def create_chat_completion(
     Returns:
         The raw response object returned by the underlying API.
     """
-
-    if not config.USE_RESPONSES_API:
+    if not use_responses_api:
         converted: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role")
@@ -108,9 +109,9 @@ async def create_chat_completion(
         raise
 
 
-def extract_text(response: Any) -> str:
+def extract_text(response: Any, use_responses_api: bool) -> str:
     """Extract the assistant text from a response object."""
-    if not config.USE_RESPONSES_API:
+    if not use_responses_api:
         try:
             return (
                 response.choices[0].message.content.strip()

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -276,13 +276,14 @@ Do not include any explanations or conversational text outside the JSON object.
                 {"role": "user", "content": user_prompt}
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
             max_tokens=8192,
             temperature=0.2,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             **response_format_arg,
         )
 
-        raw_content = extract_text(response)
+        raw_content = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
         if raw_content:
 
             if raw_content.startswith("```json"):
@@ -323,11 +324,12 @@ Do not include any explanations or conversational text outside the JSON object.
                         {"role": "user", "content": user_prompt}
                     ],
                     model=config.FAST_LLM_MODEL,
+                    use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                     max_tokens=2048,
                     temperature=0.2,
                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                 )
-                raw_content = extract_text(response)
+                raw_content = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
                 if raw_content:
                     if raw_content.startswith("```json"):
                         raw_content = raw_content[7:]
@@ -385,11 +387,12 @@ async def distill_conversation_to_sentence_llm(llm_client: Any, text_to_distill:
                 {"role": "user", "content": prompt}
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
             max_tokens=2048,
             temperature=0.5,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        distilled = extract_text(response)
+        distilled = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
         if distilled:
             logger.info(f"Distilled exchange to sentence(s): '{distilled[:100]}...'")
             return distilled
@@ -439,11 +442,12 @@ async def synthesize_retrieved_contexts_llm(llm_client: Any, retrieved_contexts:
                 {"role": "user", "content": prompt}
             ],
             model=config.LLM_MODEL,
+            use_responses_api=config.LLM_USE_RESPONSES_API,
             max_tokens=3072,
             temperature=0.6,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        synthesized_context = extract_text(response)
+        synthesized_context = extract_text(response, config.LLM_USE_RESPONSES_API)
         if synthesized_context:
             logger.info(f"Synthesized RAG context: '{synthesized_context[:150]}...'")
             return synthesized_context
@@ -486,11 +490,12 @@ async def merge_memory_snippet_with_summary_llm(
                 {"role": "user", "content": user_text},
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
             max_tokens=2048,
             temperature=0.4,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        merged = extract_text(response)
+        merged = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
         if merged:
             return merged
         logger.warning("merge_memory_snippet_with_summary_llm: LLM returned no content.")


### PR DESCRIPTION
This change introduces more granular control over which API is used for different LLM tasks.

The single `USE_RESPONSES_API` environment variable has been replaced by two new variables:
- `LLM_USE_RESPONSES_API`: Controls the API for the main LLM.
- `FAST_LLM_USE_RESPONSES_API`: Controls the API for the fast LLM.

This allows for greater flexibility in configuring the bot to use different LLM backends for different purposes, such as using a standard OpenAI-compatible API for fast tasks and a 'responses' API for the main model.