### PR TITLE
fix: Correct vision request payload and add specific config

### DIFF
--- a/config.py
+++ b/config.py
@@ -74,8 +74,10 @@ class Config:
         self.VISION_LLM_MODEL = os.getenv("VISION_LLM_MODEL", "llava")
         self.FAST_LLM_MODEL = os.getenv("FAST_LLM_MODEL", self.LLM_MODEL)
         self.LLM_API_KEY = os.getenv("LLM_API_KEY", "")
-        self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False) # New Flag
-        self.USE_RESPONSES_API = _get_bool("USE_RESPONSES_API", False)
+        self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False)
+        self.LLM_USE_RESPONSES_API = _get_bool("LLM_USE_RESPONSES_API", False)
+        self.FAST_LLM_USE_RESPONSES_API = _get_bool("FAST_LLM_USE_RESPONSES_API", False)
+        self.VISION_LLM_USE_RESPONSES_API = _get_bool("VISION_LLM_USE_RESPONSES_API", False)
         self.LLM_STREAMING = _get_bool("LLM_STREAMING", True)
         self.RESPONSES_REASONING_EFFORT = _get_choice(
             "RESPONSES_REASONING_EFFORT",

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -228,11 +228,12 @@ async def process_rss_feed(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url=feed_url,
@@ -354,11 +355,12 @@ async def process_ground_news(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url="ground_news_my",
@@ -508,11 +510,12 @@ async def process_ground_news_topic(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url=f"ground_news_topic_{topic_slug}",
@@ -625,7 +628,7 @@ async def describe_image(image_url: str) -> Optional[str]:
             {
                 "role": "user",
                 "content": [
-                    {"type": "input_text", "text": "Describe this image for a visually impaired user. Be concise and focus on the most important elements."},
+                    {"type": "text", "text": "Describe this image for a visually impaired user. Be concise and focus on the most important elements."},
                     {"type": "input_image", "image_url": image_url_for_llm}
                 ]
             }
@@ -635,11 +638,12 @@ async def describe_image(image_url: str) -> Optional[str]:
             llm_client_instance,
             prompt_messages,
             model=config.VISION_LLM_MODEL,
+            use_responses_api=config.LLM_USE_RESPONSES_API,
             max_tokens=250,
             temperature=0.3,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        description = extract_text(response)
+        description = extract_text(response, config.LLM_USE_RESPONSES_API)
         if description:
             return description
         return None
@@ -1060,11 +1064,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                             {"role": "user", "content": summarization_prompt}
                         ],
                         model=config.FAST_LLM_MODEL,
+                        use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                         max_tokens=1024,
                         temperature=0.3,
                         logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                     )
-                    article_summary = extract_text(summary_response)
+                    article_summary = extract_text(summary_response, config.FAST_LLM_USE_RESPONSES_API)
                     if article_summary:
                         logger.info(f"Summarized '{article_title}': {article_summary[:100]}...")
                         article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
@@ -1415,11 +1420,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                             {"role": "user", "content": summarization_prompt_search}
                         ],
                         model=config.FAST_LLM_MODEL,
+                        use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                         max_tokens=1024,
                         temperature=0.3,
                         logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                     )
-                    page_summary = extract_text(summary_response_search)
+                    page_summary = extract_text(summary_response_search, config.FAST_LLM_USE_RESPONSES_API)
                     if page_summary:
                         logger.info(f"Summarized '{page_title}' for search query '{query}': {page_summary[:100]}...")
                         page_summaries_for_final_synthesis.append(f"Source Page: {page_title} ({page_url})\nSummary of Page Content: {page_summary}\n\n")
@@ -1750,11 +1756,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                                 {"role": "user", "content": prompt}
                             ],
                             model=config.FAST_LLM_MODEL,
+                            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                             max_tokens=1024,
                             temperature=0.5,
                             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                         )
-                        summary = extract_text(response)
+                        summary = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
                         if summary and summary != "[LLM summarization failed]":
                             store_rss_summary(
                                 feed_url=ent["feed_url"],
@@ -2709,7 +2716,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             )
 
             user_content_for_ap_node = [
-                {"type": "input_text", "text": user_prompt if user_prompt else "Describe this image with the AP Photo celebrity twist."},
+                {"type": "text", "text": user_prompt if user_prompt else "Describe this image with the AP Photo celebrity twist."},
                 {"type": "input_image", "image_url": image_url_for_llm}
             ]
             user_msg_node = MsgNode("user", user_content_for_ap_node, name=str(interaction.user.id))

--- a/discord_events.py
+++ b/discord_events.py
@@ -250,7 +250,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
 
         current_message_content_parts.append(
             {
-                "type": "input_text",
+                "type": "text",
                 "text": user_message_text_for_processing
                 if user_message_text_for_processing
                 else "",
@@ -268,7 +268,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                         if len(img_bytes) > config.MAX_IMAGE_BYTES_FOR_PROMPT:
                             logger.warning(f"Image {attachment.filename} from {message.author.name} is too large ({len(img_bytes)} bytes). Skipping.")
                             for part in current_message_content_parts:
-                                if part["type"] == "input_text":
+                                if part["type"] == "text":
                                     part["text"] += f" [Note: Attached image '{attachment.filename}' was too large to process.]"
                                     break
                             continue
@@ -280,22 +280,22 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
                     except Exception as e:
                         logger.error(f"Error processing image attachment '{attachment.filename}': {e}", exc_info=True)
 
-        text_part_exists_with_content = any(p["type"] == "input_text" and p.get("text","").strip() for p in current_message_content_parts)
+        text_part_exists_with_content = any(p["type"] == "text" and p.get("text","").strip() for p in current_message_content_parts)
         if image_added_to_prompt and not text_part_exists_with_content:
              # ... (image text part handling remains the same)
             text_part_updated = False
             for part in current_message_content_parts:
-                if part["type"] == "input_text":
+                if part["type"] == "text":
                     part["text"] = "User sent image(s). Please describe or respond based on the image(s)."
                     text_part_updated = True
                     break
             if not text_part_updated:
-                 current_message_content_parts.insert(0, {"type": "input_text", "text": "User sent image(s). Please describe or respond based on the image(s)."})
+                 current_message_content_parts.insert(0, {"type": "text", "text": "User sent image(s). Please describe or respond based on the image(s)."})
 
 
         current_text_for_url_detection = ""
         for part in current_message_content_parts:
-            if part["type"] == "input_text":
+            if part["type"] == "text":
                 current_text_for_url_detection = part["text"];
                 break
 
@@ -400,13 +400,13 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         # as we are using their descriptions instead.
         text_part_found_and_updated = False
         for part_idx, part_dict in enumerate(current_message_content_parts):
-            if part_dict["type"] == "input_text":
+            if part_dict["type"] == "text":
                 current_message_content_parts[part_idx]["text"] = final_user_message_text_for_llm
                 text_part_found_and_updated = True
                 break
         if not text_part_found_and_updated: # Should ideally not happen if initialized correctly
             logger.error("Critical: Text part missing in current_message_content_parts before LLM call after URL processing.")
-            current_message_content_parts.insert(0, {"type": "input_text", "text": final_user_message_text_for_llm})
+            current_message_content_parts.insert(0, {"type": "text", "text": final_user_message_text_for_llm})
 
         # The rest of the logic determining user_msg_node_content_final based on current_message_content_parts
         # will now correctly use the text that includes scraped content and image descriptions.
@@ -417,7 +417,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
         has_image_content = False
 
         for part in current_message_content_parts:
-            if part.get("type") == "input_text" and str(part.get("text","")).strip():
+            if part.get("type") == "text" and str(part.get("text","")).strip():
                 has_text_content = True
             if part.get("type") == "input_image":
                 has_image_content = True
@@ -429,7 +429,7 @@ def setup_events_and_tasks(bot: commands.Bot, llm_client_in: Any, bot_state_in: 
             logger.info(f"Ignoring message from {message.author.name} as it resulted in no processable content after all stages."); return
 
         user_msg_node_content_final: Union[str, List[dict]]
-        if len(current_message_content_parts) == 1 and current_message_content_parts[0]["type"] == "input_text" and not has_image_content:
+        if len(current_message_content_parts) == 1 and current_message_content_parts[0]["type"] == "text" and not has_image_content:
             user_msg_node_content_final = current_message_content_parts[0]["text"]
         else:
             user_msg_node_content_final = current_message_content_parts

--- a/example.env
+++ b/example.env
@@ -6,7 +6,9 @@ MISTRAL_API_KEY =
 
 LLM_API_KEY =
 LLM_SUPPORTS_JSON_MODE = true
-USE_RESPONSES_API = false
+LLM_USE_RESPONSES_API = false
+FAST_LLM_USE_RESPONSES_API = false
+VISION_LLM_USE_RESPONSES_API = false
 LLM_STREAMING = false # stream token-by-token responses (requires org verification)
 # RESPONSES_REASONING_EFFORT = medium
 # RESPONSES_VERBOSITY = medium

--- a/llm_request_processor.py
+++ b/llm_request_processor.py
@@ -153,11 +153,12 @@ async def llm_request_processor_task(bot_state: BotState, llm_client: Any, bot_i
                                         {"role": "user", "content": summarization_prompt}
                                     ],
                                     model=config.FAST_LLM_MODEL,
+                                    use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                                     max_tokens=250,
                                     temperature=0.3,
                                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                                 )
-                                article_summary = extract_text(summary_response)
+                                article_summary = extract_text(summary_response, config.FAST_LLM_USE_RESPONSES_API)
                                 if article_summary:
                                     article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
                                     store_news_summary(topic=topic, url=article_url, summary_text=article_summary) # Assuming this is thread-safe or handled
@@ -312,7 +313,7 @@ async def llm_request_processor_task(bot_state: BotState, llm_client: Any, bot_i
                             image_url_for_llm = f"data:{ap_data.image_content_type};base64,{ap_data.image_b64}"
 
                             user_content_for_ap_node_list = [
-                                {"type": "input_text", "text": ap_data.user_prompt_text},
+                                {"type": "text", "text": ap_data.user_prompt_text},
                                 {"type": "input_image", "image_url": image_url_for_llm}
                             ]
                             user_msg_node_ap = MsgNode("user", user_content_for_ap_node_list, name=ap_data.base_user_id_for_node)

--- a/openai_api.py
+++ b/openai_api.py
@@ -15,6 +15,7 @@ async def create_chat_completion(
     llm_client: Any,
     messages: Sequence[Dict[str, Any]],
     model: str,
+    use_responses_api: bool,
     max_tokens: Optional[int] = None,
     temperature: Optional[float] = None,
     logit_bias: Optional[Dict[str, int]] = None,
@@ -29,6 +30,7 @@ async def create_chat_completion(
             In Chat Completions they are converted to ``system`` messages; in
             Responses they remain ``developer`` messages.
         model: Model name to use.
+        use_responses_api: If True, use the Responses API format.
         max_tokens: Maximum tokens for the response. For Chat Completions this
             is sent as ``max_completion_tokens``; for Responses it becomes
             ``max_output_tokens``.
@@ -39,8 +41,7 @@ async def create_chat_completion(
     Returns:
         The raw response object returned by the underlying API.
     """
-
-    if not config.USE_RESPONSES_API:
+    if not use_responses_api:
         converted: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role")
@@ -108,9 +109,9 @@ async def create_chat_completion(
         raise
 
 
-def extract_text(response: Any) -> str:
+def extract_text(response: Any, use_responses_api: bool) -> str:
     """Extract the assistant text from a response object."""
-    if not config.USE_RESPONSES_API:
+    if not use_responses_api:
         try:
             return (
                 response.choices[0].message.content.strip()

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -276,13 +276,14 @@ Do not include any explanations or conversational text outside the JSON object.
                 {"role": "user", "content": user_prompt}
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
             max_tokens=8192,
             temperature=0.2,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             **response_format_arg,
         )
 
-        raw_content = extract_text(response)
+        raw_content = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
         if raw_content:
 
             if raw_content.startswith("```json"):
@@ -323,11 +324,12 @@ Do not include any explanations or conversational text outside the JSON object.
                         {"role": "user", "content": user_prompt}
                     ],
                     model=config.FAST_LLM_MODEL,
+                    use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
                     max_tokens=2048,
                     temperature=0.2,
                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                 )
-                raw_content = extract_text(response)
+                raw_content = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
                 if raw_content:
                     if raw_content.startswith("```json"):
                         raw_content = raw_content[7:]
@@ -385,11 +387,12 @@ async def distill_conversation_to_sentence_llm(llm_client: Any, text_to_distill:
                 {"role": "user", "content": prompt}
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
             max_tokens=2048,
             temperature=0.5,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        distilled = extract_text(response)
+        distilled = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
         if distilled:
             logger.info(f"Distilled exchange to sentence(s): '{distilled[:100]}...'")
             return distilled
@@ -439,11 +442,12 @@ async def synthesize_retrieved_contexts_llm(llm_client: Any, retrieved_contexts:
                 {"role": "user", "content": prompt}
             ],
             model=config.LLM_MODEL,
+            use_responses_api=config.LLM_USE_RESPONSES_API,
             max_tokens=3072,
             temperature=0.6,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        synthesized_context = extract_text(response)
+        synthesized_context = extract_text(response, config.LLM_USE_RESPONSES_API)
         if synthesized_context:
             logger.info(f"Synthesized RAG context: '{synthesized_context[:150]}...'")
             return synthesized_context
@@ -486,11 +490,12 @@ async def merge_memory_snippet_with_summary_llm(
                 {"role": "user", "content": user_text},
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
             max_tokens=2048,
             temperature=0.4,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        merged = extract_text(response)
+        merged = extract_text(response, config.FAST_LLM_USE_RESPONSES_API)
         if merged:
             return merged
         logger.warning("merge_memory_snippet_with_summary_llm: LLM returned no content.")


### PR DESCRIPTION
This commit addresses a `BadRequestError` caused by an invalid content type in vision requests. The hardcoded `"type": "input_text"` has been corrected to `"type": "text"` to comply with the OpenAI API standard.

Additionally, this change introduces a new dedicated environment variable, `VISION_LLM_USE_RESPONSES_API`, to allow independent control over the API format for vision requests, separating it from the main text LLM configuration.