### PR TITLE
Fix completion API message conversion

### DIFF
--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -766,12 +766,25 @@ def _format_msg_content_for_text(content: Any) -> str:
     if isinstance(content, str):
         return content
     elif isinstance(content, list):
-        text_parts = [part["text"] for part in content if isinstance(part, dict) and part.get("type") == "text" and "text" in part]
+        text_parts = [
+            part["text"]
+            for part in content
+            if isinstance(part, dict)
+            and part.get("type") in {"text", "input_text"}
+            and "text" in part
+        ]
         if text_parts:
             return " ".join(text_parts)
-        has_image = any(isinstance(part, dict) and part.get("type") == "image_url" for part in content)
+        has_image = any(
+            isinstance(part, dict) and part.get("type") in {"image_url", "input_image"}
+            for part in content
+        )
         if has_image:
-            return "[User sent an image with no accompanying text]" if not text_parts else "[User sent an image]"
+            return (
+                "[User sent an image with no accompanying text]"
+                if not text_parts
+                else "[User sent an image]"
+            )
     return "[Unsupported content format]"
 
 


### PR DESCRIPTION
## Summary
- Convert internal `input_text`/`input_image` messages to Chat Completions formats when using the completions API
- Recognize both `input_*` and legacy content types when formatting conversation text for RAG

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897d666667483289593398e26ddc26b