### PR TITLE
Fix: Correctly use youtube-transcript-api library

### DIFF
--- a/web_utils.py
+++ b/web_utils.py
@@ -671,7 +671,8 @@ async def fetch_youtube_transcript(url: str) -> Optional[str]:
         video_id = video_id_match.group(1)
         logger.info(f"Fetching YouTube transcript for video ID: {video_id} (from URL: {url})")
 
-        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        api = YouTubeTranscriptApi()
+        transcript_list = api.list(video_id)
         transcript_obj: Optional[Any] = None
 
         try:


### PR DESCRIPTION
The `fetch_youtube_transcript` function was failing with an `AttributeError` because it was attempting to call methods on the `YouTubeTranscriptApi` class statically.

Based on the library's documentation, this change corrects the implementation to first create an instance of the `YouTubeTranscriptApi` class and then call the `list()` method on that instance.

This resolves the `AttributeError` and correctly aligns the code with the library's intended usage, restoring the transcript fetching functionality.