### PR TITLE
Feat: Make Completions/Responses API usage configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `VISION_LLM_MODEL` (Default: `llava`): The model used for tasks involving image understanding (e.g., the `/ap` command or describing screenshots).
 *   `LLM_SUPPORTS_JSON_MODE` (Default: `false`): Set to `true` if your LLM server and the selected model support JSON mode for structured output (e.g., for entity extraction).
 *   `IS_GOOGLE_MODEL` (Default: `false`): Set to `true` if you are using a Google Gemini model via an OpenAI-compatible endpoint. This disables unsupported features like `logit_bias` to prevent errors.
-*   `USE_RESPONSES_API` (Default: `false`): When `true`, use OpenAI's Responses API instead of legacy Chat Completions. System prompts are passed via the `instructions` field and model names may require the orchestrator variant (e.g., `gpt-4o`).
+*   `LLM_USE_RESPONSES_API` (Default: `false`): When `true`, use the Responses API instead of Chat Completions for the main `LLM` model.
+*   `VISION_LLM_USE_RESPONSES_API` (Default: `false`): When `true`, use the Responses API instead of Chat Completions for the `VISION_LLM_MODEL`.
+*   `FASTLLM_USE_RESPONSES_API` (Default: `false`): When `true`, use the Responses API instead of Chat Completions for the `FAST_LLM_MODEL`.
 *   `LLM_STREAMING` (Default: `false`): Stream token-by-token responses when `true`. Some models require organization verification to enable streaming.
 *   `RESPONSES_REASONING_EFFORT` (Optional): Controls the reasoning effort for Responses models. Options are `minimal`, `low`, `medium`, or `high`.
 *   `RESPONSES_VERBOSITY` (Optional): Sets the verbosity of Responses output. Options are `low`, `medium`, or `high`.

--- a/config.py
+++ b/config.py
@@ -76,7 +76,9 @@ class Config:
         self.LLM_API_KEY = os.getenv("LLM_API_KEY", "")
         self.LLM_SUPPORTS_JSON_MODE = _get_bool("LLM_SUPPORTS_JSON_MODE", False) # New Flag
         self.IS_GOOGLE_MODEL = _get_bool("IS_GOOGLE_MODEL", False)
-        self.USE_RESPONSES_API = _get_bool("USE_RESPONSES_API", False)
+        self.LLM_USE_RESPONSES_API = _get_bool("LLM_USE_RESPONSES_API", False)
+        self.VISION_LLM_USE_RESPONSES_API = _get_bool("VISION_LLM_USE_RESPONSES_API", False)
+        self.FASTLLM_USE_RESPONSES_API = _get_bool("FASTLLM_USE_RESPONSES_API", False)
         self.LLM_STREAMING = _get_bool("LLM_STREAMING", True)
         self.RESPONSES_REASONING_EFFORT = _get_choice(
             "RESPONSES_REASONING_EFFORT",

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -228,11 +228,12 @@ async def process_rss_feed(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url=feed_url,
@@ -354,11 +355,12 @@ async def process_ground_news(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url="ground_news_my",
@@ -508,11 +510,12 @@ async def process_ground_news_topic(
                     {"role": "user", "content": prompt}
                 ],
                 model=config.FAST_LLM_MODEL,
+                use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                 max_tokens=1024,
                 temperature=0.5,
                 logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             )
-            summary = extract_text(response)
+            summary = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
             if summary and summary != "[LLM summarization failed]":
                 store_rss_summary(
                     feed_url=f"ground_news_topic_{topic_slug}",
@@ -617,7 +620,8 @@ async def describe_image(image_url: str) -> Optional[str]:
         base64_image = base64.b64encode(image_bytes).decode('utf-8')
         image_url_for_llm = f"data:image/jpeg;base64,{base64_image}"
 
-        if config.USE_RESPONSES_API:
+        use_responses_api = config.VISION_LLM_USE_RESPONSES_API
+        if use_responses_api:
             prompt_messages = [
                 {
                     "role": "system",
@@ -653,11 +657,12 @@ async def describe_image(image_url: str) -> Optional[str]:
             llm_client_instance,
             prompt_messages,
             model=config.VISION_LLM_MODEL,
+            use_responses_api=use_responses_api,
             max_tokens=250,
             temperature=0.3,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        description = extract_text(response)
+        description = extract_text(response, use_responses_api=use_responses_api)
         if description:
             return description
         return None
@@ -1078,11 +1083,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                             {"role": "user", "content": summarization_prompt}
                         ],
                         model=config.FAST_LLM_MODEL,
+                        use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                         max_tokens=1024,
                         temperature=0.3,
                         logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                     )
-                    article_summary = extract_text(summary_response)
+                    article_summary = extract_text(summary_response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
                     if article_summary:
                         logger.info(f"Summarized '{article_title}': {article_summary[:100]}...")
                         article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
@@ -1271,7 +1277,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
 
         try:
             webpage_text = await scrape_website(url)
-            if not webpage_text or "Failed to scrape" in webpage_text or "Scraping timed out" in webpage_text:
+            if not webpage_text or "Failed to scrape" in webpage_text or "Scraping timed out" in scraped_text:
                 error_message = f"Sorry, I couldn't properly roast {url}. Reason: {webpage_text or 'Could not retrieve any content from the page.'}"
                 if interaction.channel:
                     progress_message = await safe_message_edit(
@@ -1433,11 +1439,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                             {"role": "user", "content": summarization_prompt_search}
                         ],
                         model=config.FAST_LLM_MODEL,
+                        use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                         max_tokens=1024,
                         temperature=0.3,
                         logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                     )
-                    page_summary = extract_text(summary_response_search)
+                    page_summary = extract_text(summary_response_search, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
                     if page_summary:
                         logger.info(f"Summarized '{page_title}' for search query '{query}': {page_summary[:100]}...")
                         page_summaries_for_final_synthesis.append(f"Source Page: {page_title} ({page_url})\nSummary of Page Content: {page_summary}\n\n")
@@ -1449,7 +1456,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 except Exception as e_summ_search:
                     logger.error(f"Error during LLM summarization for '{page_title}' (search query '{query}'): {e_summ_search}", exc_info=True)
                     page_summaries_for_final_synthesis.append(f"Source Page: {page_title} ({page_url})\nSummary: [Error during AI summarization]\n\n")
-            
+
             if not page_summaries_for_final_synthesis:
                 error_embed_search = discord.Embed(
                     title=f"Search Results for: {query}",
@@ -1768,11 +1775,12 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                                 {"role": "user", "content": prompt}
                             ],
                             model=config.FAST_LLM_MODEL,
+                            use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                             max_tokens=1024,
                             temperature=0.5,
                             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                         )
-                        summary = extract_text(response)
+                        summary = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
                         if summary and summary != "[LLM summarization failed]":
                             store_rss_summary(
                                 feed_url=ent["feed_url"],
@@ -2726,7 +2734,8 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                 f"If the user provided an additional prompt, try to incorporate its theme or request into your {chosen_celebrity}-centric description: '{user_prompt if user_prompt else 'No additional user prompt.'}'"
             )
 
-            if config.USE_RESPONSES_API:
+            use_responses_api = config.VISION_LLM_USE_RESPONSES_API
+            if use_responses_api:
                 user_content_for_ap_node = [
                     {"type": "input_text", "text": user_prompt if user_prompt else "Describe this image with the AP Photo celebrity twist."},
                     {"type": "input_image", "image_url": image_url_for_llm}

--- a/example.env
+++ b/example.env
@@ -6,7 +6,11 @@ MISTRAL_API_KEY =
 
 LLM_API_KEY =
 LLM_SUPPORTS_JSON_MODE = true
-USE_RESPONSES_API = false
+# Set to true to use the Responses API instead of Chat Completions for a given model type.
+# This may require account verification. Streaming is not supported with the Responses API.
+LLM_USE_RESPONSES_API=False
+VISION_LLM_USE_RESPONSES_API=False
+FASTLLM_USE_RESPONSES_API=False
 LLM_STREAMING = false # stream token-by-token responses (requires org verification)
 # RESPONSES_REASONING_EFFORT = medium
 # RESPONSES_VERBOSITY = medium

--- a/llm_request_processor.py
+++ b/llm_request_processor.py
@@ -153,11 +153,12 @@ async def llm_request_processor_task(bot_state: BotState, llm_client: Any, bot_i
                                         {"role": "user", "content": summarization_prompt}
                                     ],
                                     model=config.FAST_LLM_MODEL,
+                                    use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                                     max_tokens=250,
                                     temperature=0.3,
                                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                                 )
-                                article_summary = extract_text(summary_response)
+                                article_summary = extract_text(summary_response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
                                 if article_summary:
                                     article_summaries_for_briefing.append(f"Source: {article_title} ({article_url})\nSummary: {article_summary}\n\n")
                                     store_news_summary(topic=topic, url=article_url, summary_text=article_summary) # Assuming this is thread-safe or handled

--- a/openai_api.py
+++ b/openai_api.py
@@ -15,6 +15,7 @@ async def create_chat_completion(
     llm_client: Any,
     messages: Sequence[Dict[str, Any]],
     model: str,
+    use_responses_api: bool,
     max_tokens: Optional[int] = None,
     temperature: Optional[float] = None,
     logit_bias: Optional[Dict[str, int]] = None,
@@ -29,6 +30,7 @@ async def create_chat_completion(
             In Chat Completions they are converted to ``system`` messages; in
             Responses they remain ``developer`` messages.
         model: Model name to use.
+        use_responses_api: If True, the Responses API will be used.
         max_tokens: Maximum tokens for the response. For Chat Completions this
             is sent as ``max_completion_tokens``; for Responses it becomes
             ``max_output_tokens``.
@@ -40,7 +42,7 @@ async def create_chat_completion(
         The raw response object returned by the underlying API.
     """
 
-    if not config.USE_RESPONSES_API:
+    if not use_responses_api:
         converted: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role")
@@ -108,9 +110,9 @@ async def create_chat_completion(
         raise
 
 
-def extract_text(response: Any) -> str:
+def extract_text(response: Any, use_responses_api: bool) -> str:
     """Extract the assistant text from a response object."""
-    if not config.USE_RESPONSES_API:
+    if not use_responses_api:
         try:
             return (
                 response.choices[0].message.content.strip()

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -276,13 +276,14 @@ Do not include any explanations or conversational text outside the JSON object.
                 {"role": "user", "content": user_prompt}
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FASTLLM_USE_RESPONSES_API,
             max_tokens=8192,
             temperature=0.2,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
             **response_format_arg,
         )
 
-        raw_content = extract_text(response)
+        raw_content = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
         if raw_content:
 
             if raw_content.startswith("```json"):
@@ -323,11 +324,12 @@ Do not include any explanations or conversational text outside the JSON object.
                         {"role": "user", "content": user_prompt}
                     ],
                     model=config.FAST_LLM_MODEL,
+                    use_responses_api=config.FASTLLM_USE_RESPONSES_API,
                     max_tokens=8192,
                     temperature=0.2,
                     logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
                 )
-                raw_content = extract_text(response)
+                raw_content = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
                 if raw_content:
                     if raw_content.startswith("```json"):
                         raw_content = raw_content[7:]
@@ -385,11 +387,12 @@ async def distill_conversation_to_sentence_llm(llm_client: Any, text_to_distill:
                 {"role": "user", "content": prompt}
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FASTLLM_USE_RESPONSES_API,
             max_tokens=2048,
             temperature=0.5,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        distilled = extract_text(response)
+        distilled = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
         if distilled:
             logger.info(f"Distilled exchange to sentence(s): '{distilled[:100]}...'")
             return distilled
@@ -439,11 +442,12 @@ async def synthesize_retrieved_contexts_llm(llm_client: Any, retrieved_contexts:
                 {"role": "user", "content": prompt}
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FASTLLM_USE_RESPONSES_API,
             max_tokens=3072,
             temperature=0.6,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        synthesized_context = extract_text(response)
+        synthesized_context = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
         if synthesized_context:
             logger.info(f"Synthesized RAG context: '{synthesized_context[:150]}...'")
             return synthesized_context
@@ -465,7 +469,7 @@ async def merge_memory_snippet_with_summary_llm(
     prompt = (
         "You maintain long-term memories for an AI assistant. "
         "Rewrite the existing memory with any new insights from the conversation summary. "
-        "Return 3-8 concise sentences that preserve important older details and incorporate the new information." 
+        "Return 3-8 concise sentences that preserve important older details and incorporate the new information."
     )
 
     timestamp_match = re.search(r"Conversation recorded at:\s*(.+)", old_memory)
@@ -486,11 +490,12 @@ async def merge_memory_snippet_with_summary_llm(
                 {"role": "user", "content": user_text},
             ],
             model=config.FAST_LLM_MODEL,
+            use_responses_api=config.FASTLLM_USE_RESPONSES_API,
             max_tokens=2048,
             temperature=0.4,
             logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
         )
-        merged = extract_text(response)
+        merged = extract_text(response, use_responses_api=config.FASTLLM_USE_RESPONSES_API)
         if merged:
             return merged
         logger.warning("merge_memory_snippet_with_summary_llm: LLM returned no content.")


### PR DESCRIPTION
Replaces the single `USE_RESPONSES_API` environment variable with three separate flags:
- `LLM_USE_RESPONSES_API`
- `VISION_LLM_USE_RESPONSES_API`
- `FASTLLM_USE_RESPONSES_API`

This allows for mixing and matching the completions and responses APIs for different models.

The `create_chat_completion` and `extract_text` functions in `openai_api.py` have been refactored to accept a `use_responses_api` boolean argument.

All call sites for `create_chat_completion` have been updated to pass the appropriate configuration flag, ensuring that the correct API is used for each model type.