### PR TITLE
feat: Allow specifying Whisper device for GPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `MAX_MESSAGE_HISTORY` (Default: `10`): The maximum number of recent messages (user and assistant turns) to include in the short-term context sent to the LLM.
 *   `MAX_COMPLETION_TOKENS` (Default: `2048`): The maximum number of tokens the LLM is allowed to generate in a single response.
 
+**Whisper (Audio Transcription) Settings:**
+
+*   `WHISPER_DEVICE` (Optional): Specify the device for Whisper to run on. Common values are `cuda` for NVIDIA GPUs or `cpu`. If not set, Whisper will attempt to auto-detect the best available device. This is useful for forcing GPU usage if auto-detection fails.
+
 **Text-to-Speech (TTS) Settings:**
 
 *   `TTS_ENABLED_DEFAULT` (Default: `true`): Whether TTS is enabled by default for bot responses.
@@ -569,7 +573,7 @@ Several helper scripts are provided for upkeep and optional functionality:
 
 DiscordSam is a project with significant potential for growth. Here are some ideas for future enhancements:
 
-*   **Enhanced RAG Strategies:** More sophisticated summarization, knowledge graph integration, hybrid search, advanced query understanding for RAG.
+*   **Enhanced RAG Strategies:** More-sophisticated summarization, knowledge graph integration, hybrid search, advanced query understanding for RAG.
 *   **Expanded LLM/Multimodal Support:** Support for more LLM backends, true multimodal inputs/outputs beyond simple image description, advanced agentic capabilities (e.g., function calling, planning).
 *   **Slash Command Enhancements:** New creative tools, personalization features (user-specific settings), integration with more external services (e.g., calendar, project management).
 *   **Improved Error Handling & Resilience:** More granular error reporting to users, graceful degradation of services when components are unavailable.
@@ -589,5 +593,3 @@ Found a bug? Have a feature request? Want to contribute?
 *   If you'd like to contribute code, please **fork the repository** and submit a **pull request** with your changes. Ensure your code follows existing style conventions and consider adding tests for new features.
 
 We welcome contributions to improve and expand DiscordSam!
-
-

--- a/audio_utils.py
+++ b/audio_utils.py
@@ -56,8 +56,12 @@ def load_whisper_model() -> Optional[Any]:
     with WHISPER_LOCK:
         if WHISPER_MODEL is None:
             try:
-                logger.info("Loading Whisper model...")
-                WHISPER_MODEL = whisper.load_model("large-v3-turbo")
+                device = config.WHISPER_DEVICE
+                if device:
+                    logger.info(f"Loading Whisper model onto specified device: {device}...")
+                else:
+                    logger.info("Loading Whisper model with auto-device-detection...")
+                WHISPER_MODEL = whisper.load_model("large-v3-turbo", device=device)
                 logger.info("Whisper model loaded successfully.")
             except Exception as e:
                 logger.critical(f"Failed to load Whisper model: {e}", exc_info=True)

--- a/config.py
+++ b/config.py
@@ -87,6 +87,9 @@ class Config:
             "VISION_LLM_USE_RESPONSES_API", self.USE_RESPONSES_API
         )
         self.LLM_STREAMING = _get_bool("LLM_STREAMING", True)
+
+        # Whisper ASR model settings
+        self.WHISPER_DEVICE = os.getenv("WHISPER_DEVICE") # e.g. "cuda", "cpu". None for auto-detect
         self.RESPONSES_REASONING_EFFORT = _get_choice(
             "RESPONSES_REASONING_EFFORT",
             {"minimal", "low", "medium", "high"},


### PR DESCRIPTION
I've added a `WHISPER_DEVICE` environment variable to allow you to explicitly set the device for the Whisper model.

- The `Config` class in `config.py` now reads `WHISPER_DEVICE` from the environment.
- The `load_whisper_model` function in `audio_utils.py` uses this new setting to pass a `device` parameter (e.g., "cuda") to `whisper.load_model()`.
- This allows you to force Whisper to use the GPU if auto-detection is not working correctly in your environment.
- I have also documented the new setting in `README.md`.