### PR TITLE
Add configurable TTS text chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Below is a comprehensive list of environment variables used by DiscordSam, along
 *   `TTS_VOICE` (Default: `af_sky+af+af_nicole`): The voice to be used for TTS generation. The format may depend on your TTS server.
 *   `TTS_MAX_AUDIO_BYTES` (Default: `8388608` (8MB)): Maximum size of a single generated TTS audio clip. Longer audio will be split into parts before uploading to stay under Discord's attachment limits.
 *   `TTS_SPEED` (Default: `1.3`): Playback speed multiplier for TTS audio. Use `1.0` for normal speed.
+*   `TTS_TEXT_CHUNK_SIZE` (Default: `500`): Maximum number of characters per TTS request. Longer text is split into multiple audio clips.
 *   `TTS_INCLUDE_THOUGHTS` (Default: `false`): If `true`, content within `<think>...</think>` tags will also be spoken using TTS. When `false`, only the user-facing portion of the response is processed.
 
 **Web Features & Scraping:**

--- a/config.py
+++ b/config.py
@@ -119,6 +119,7 @@ class Config:
         # Use 8MB as the default so TTS audio gets split automatically if needed.
         self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)
         self.TTS_SPEED = _get_float("TTS_SPEED", 1.3)
+        self.TTS_TEXT_CHUNK_SIZE = _get_int("TTS_TEXT_CHUNK_SIZE", 500)
 
         self.SEARX_URL = os.getenv("SEARX_URL", "http://192.168.1.3:9092/search")
         # Changed default for SEARX_PREFERENCES to an empty string.

--- a/example.env
+++ b/example.env
@@ -35,6 +35,7 @@ TTS_ENABLED_DEFAULT = true # true or false
 TTS_MAX_AUDIO_BYTES = 8388608
 TTS_SPEED = 1.3
 TTS_INCLUDE_THOUGHTS = false
+TTS_TEXT_CHUNK_SIZE = 500
 
 CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
 


### PR DESCRIPTION
## Summary
- add `TTS_TEXT_CHUNK_SIZE` to limit characters per text-to-speech request
- split TTS text into chunks and send each audio clip sequentially
- document the new setting in README and example.env

## Testing
- `python -m py_compile config.py audio_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689a959dd4c48328ac0e1f0b9edefaf4