### PR TITLE
I've increased the TTS request timeout and improved the logging.

### DIFF
--- a/audio_utils.py
+++ b/audio_utils.py
@@ -80,16 +80,17 @@ async def tts_request(text: str, speed: Optional[float] = None) -> Optional[byte
         "response_format": "mp3",
         "speed": speed,
     }
+    logger.info(f"Requesting TTS for {len(text)} characters.")
     try:
         async with aiohttp.ClientSession() as session:
-            async with session.post(config.TTS_API_URL, json=payload, timeout=90) as resp:
+            async with session.post(config.TTS_API_URL, json=payload, timeout=config.TTS_REQUEST_TIMEOUT_SECONDS) as resp:
                 if resp.status == 200:
                     return await resp.read()
                 else:
                     logger.error(f"TTS request failed: status={resp.status}, response_text={await resp.text()}")
                     return None
     except asyncio.TimeoutError:
-        logger.error("TTS request timed out.")
+        logger.error(f"TTS request timed out after {config.TTS_REQUEST_TIMEOUT_SECONDS} seconds for {len(text)} characters.")
         return None
     except Exception as e:
         logger.error(f"TTS request error: {e}", exc_info=True)

--- a/config.py
+++ b/config.py
@@ -119,6 +119,7 @@ class Config:
         # Use 8MB as the default so TTS audio gets split automatically if needed.
         self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)
         self.TTS_SPEED = _get_float("TTS_SPEED", 1.3)
+        self.TTS_REQUEST_TIMEOUT_SECONDS = _get_int("TTS_REQUEST_TIMEOUT_SECONDS", 180)
 
         self.SEARX_URL = os.getenv("SEARX_URL", "http://192.168.1.3:9092/search")
         # Changed default for SEARX_PREFERENCES to an empty string.


### PR DESCRIPTION
I found that the TTS API was timing out on large inputs due to a hardcoded 90-second timeout.

To fix this, I introduced a new configuration variable, `TTS_REQUEST_TIMEOUT_SECONDS`, with a default of 180 seconds. This makes the timeout configurable and less prone to failure on large inputs.

I also improved the logging for the TTS request function to include the character count of the text being processed. This will aid you in debugging any future timeout or request issues.