### PR TITLE
Improve text cleaning for TTS requests.

### DIFF
--- a/audio_utils.py
+++ b/audio_utils.py
@@ -80,16 +80,17 @@ async def tts_request(text: str, speed: Optional[float] = None) -> Optional[byte
         "response_format": "mp3",
         "speed": speed,
     }
+    logger.info(f"Requesting TTS for {len(text)} characters.")
     try:
         async with aiohttp.ClientSession() as session:
-            async with session.post(config.TTS_API_URL, json=payload, timeout=90) as resp:
+            async with session.post(config.TTS_API_URL, json=payload, timeout=config.TTS_REQUEST_TIMEOUT_SECONDS) as resp:
                 if resp.status == 200:
                     return await resp.read()
                 else:
                     logger.error(f"TTS request failed: status={resp.status}, response_text={await resp.text()}")
                     return None
     except asyncio.TimeoutError:
-        logger.error("TTS request timed out.")
+        logger.error(f"TTS request timed out after {config.TTS_REQUEST_TIMEOUT_SECONDS} seconds for {len(text)} characters.")
         return None
     except Exception as e:
         logger.error(f"TTS request error: {e}", exc_info=True)

--- a/config.py
+++ b/config.py
@@ -119,6 +119,8 @@ class Config:
         # Use 8MB as the default so TTS audio gets split automatically if needed.
         self.TTS_MAX_AUDIO_BYTES = _get_int("TTS_MAX_AUDIO_BYTES", 8 * 1024 * 1024)
         self.TTS_SPEED = _get_float("TTS_SPEED", 1.3)
+        self.TTS_REQUEST_TIMEOUT_SECONDS = _get_int("TTS_REQUEST_TIMEOUT_SECONDS", 180)
+        self.TTS_CHARACTER_LIMIT = _get_int("TTS_CHARACTER_LIMIT", 2500)
 
         self.SEARX_URL = os.getenv("SEARX_URL", "http://192.168.1.3:9092/search")
         # Changed default for SEARX_PREFERENCES to an empty string.

--- a/utils.py
+++ b/utils.py
@@ -98,14 +98,26 @@ def append_absolute_dates(
     return text
 
 def clean_text_for_tts(text: str) -> str:
-    if not text: return ""
-    # Remove Markdown-like characters, including full-width parentheses
-    text = re.sub(r'[\*#_~\<\>\[\]\(\)（）]+', '', text)
-    # Remove URLs
-    text = re.sub(r'http[s]?://\S+', '', text)
-    # Remove <think> tags and their content
-    text = re.sub(r'<think>.*?</think>', '', text, flags=re.DOTALL | re.IGNORECASE)
-    return text.strip()
+    if not text:
+        return ""
+    # 1. Remove URLs and <think> tags first, as they can contain complex characters.
+    text = re.sub(r"http[s]?://\S+", "", text)
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
+
+    # 2. Define a whitelist of characters to keep.
+    # This includes letters (unicode), numbers, basic punctuation, and whitespace.
+    # This is safer than a blacklist for preventing unknown "special characters".
+    # \w includes unicode letters, numbers, and underscore.
+    # We add common punctuation and the hyphen.
+    allowed_chars = re.compile(r"[^\w\s.,!?'\"-]")
+
+    # 3. Remove all characters that are not in the whitelist.
+    text = allowed_chars.sub("", text)
+
+    # 4. Clean up excessive whitespace that might result from the substitution.
+    text = re.sub(r"\s+", " ", text).strip()
+
+    return text
 
 def parse_time_string_to_delta(time_str: str) -> Tuple[Optional[timedelta], Optional[str]]:
     patterns = {


### PR DESCRIPTION
The TTS service was failing intermittently on certain inputs. The root cause was identified as the presence of special characters in the text that the TTS engine could not handle.

This change replaces the previous blacklist-based cleaning in `clean_text_for_tts` with a more robust whitelist-based approach. The new function removes any characters that are not explicitly in a safe set (letters, numbers, basic punctuation), making it much more effective at preventing invalid characters from being sent to the TTS service.