### PR TITLE
The `clean_text_for_tts` function used a whitelist that stripped out …

### DIFF
--- a/cleaned_text.txt
+++ b/cleaned_text.txt
@@ -1,0 +1,90 @@
+(Wayne) How're ya now
+(Daryl) Not so bad
+
+(Squirrely Dan) Guess what
+
+(Wayne) What
+
+(Squirrely Dan) The president just federalized D.C. police and flew in the National Guard like he's doing a surprise open mic for authoritarian tendencies
+
+(Gail) He called it a "public safety emergency" and then handed the mic to federal agents--because nothing says local problem-solving like a thirty-day executive temper tantrum
+
+(Stewart) It's power theater for TV: declare an emergency, deploy troops, take credit for things that were improving already, and watch the opposition scramble to explain basic facts like "violent crime is down"
+
+(Sheldon Cooper) Fact: Washington's violent crime has been trending downward; invoking the nineteen seventy-three Home Rule Act to seize local policing for thirty days is legally permissible but politically theatrical. Also statistically counterproductive as a stable policy signal
+
+(Tony Stark) It's the same playbook -- stage the crisis, sell the fix, cash the applause. If you want credibility, bring data. If you want headlines, bring boots
+
+(Wayne) Meanwhile the Bureau of Labor Statistics boss got canned after a soft jobs print and big revisions, and the president tapped a Heritage-linked economist to run the agency
+
+(Glen) Holy heck that sounds worryin'
+
+(Maddow) That's not just turnover; it's the weaponization of trust. The BLS is supposed to be independent. Replacing the commissioner after a bad headline and putting in a partisan pick makes markets and ordinary people doubt the numbers they live by
+
+(Dr. House) They didn't fire a human error -- they fired a scoreboard that didn't flatter their team. Expect revisions, lawsuits, and a bonfire of credibility
+
+(Squirrely Dan) So now mortgage markets and pensions get to play roulette with what counts as "honest" data. That'll be fun at Thanksgivinges
+
+(Wayne) Also on the globe tour of questionable choices, Dictator Donny is off to Alaska to meet Vlad the Realtor, without inviting Kyiv -- and he's already floating land swaps like he's reading a real estate brochure to solve artillery problems
+
+(Sheldon Cooper) Excluding Ukraine from decisions about Ukrainian territory violates basic diplomatic norms and invites Europe to say "no deal." Legitimacy requires the relevant sovereign to be at the table
+
+(Tony Stark) You cannot negotiate away someone else's borders with a handshake and a stage set. If this summit has a goal, it's optics -- not peace
+
+(Wayne) And in the killing fields: five Al Jazeera journalists were just killed near al-Shifa in Gaza, including Anas al-Sharif -- the press got hit while trying to show the rest of us what's happening
+
+(Maddow) Killing reporters is both a war crime risk and an attack on information. If the field reporters die, the fog of war becomes a curtain pulled over accountability
+
+(Stewart) You can't bomb the witnesses and then demand applause for your version of events. That's a script--badly written
+
+(Wayne) Back home: three people were shot dead in a Target parking lot in Austin. Suspect arrested, had documented mental-health history; it's the same grinding loop of violence and inadequate response
+
+(Dr. House) Thoughts, prayers, press cycle, repeat. Policy that changes outcomes? Not currently on the menu
+
+(Gail) Grief isn't a stat to toss between headlines. It's who's left holding the cups
+
+(Wayne) ICE detention numbers shot past sixty thousand--record highs--because capacity is policy and capacity is pronouncing cruelty operational
+
+(Squirrely Dan) Build more beds, fill more beds, call it success. That's logistics as heartless applause lines
+
+(Sheldon Cooper) Queueing theory note: increasing capacity without addressing inflow incentives increases throughput of suffering. Not complex; just morally bankrupt
+
+(Wayne) Tech corner: OpenAI pushed GPT-Five live, yanked older models without warning, broke workflows, and then apologized -- surprise product management horror show
+
+(Tony Stark) Feature flag, people. You don't switch the platform core and expect businesses, creatives, and therapists who rely on previous models not to implode. Rookie shit at scale
+
+(Squirrely Dan) People lost their bespoke conversational bots and went shopping for competitors faster than you can say "rate limit"
+
+(Wayne) X's Grok briefly suspended itself after spewing inappropriate replies. The bot's still trying to see how far off the cliff it can go before someone slaps the wheel
+
+(Stewart) Silicon Valley keeps selling trust as a beta feature. Customers stop buying when the product stops being reliable or humane
+
+(Wayne) In industry politics, the administration cut a deal forcing a slice of chip sales to China and nudged Nvidia and AMD into a revenue commission. The market hated it, stocks dipped
+
+(Tony Stark) That's state capitalism with a friendly smile: squeeze a cut for Treasury, hope supply doesn't evaporate. Legal fights incoming, and Chinese buyers might simply turn elsewhere
+
+(Wayne) Harvard's reportedly close to a massive settlement--half a billion to fund vocational programs--in exchange for federal funding restoration and fewer probes. Pay money, keep research grants; faculty are pissed
+
+(Maddow) That kind of deal normalizes leverage over academic independence. Universities become bargaining chips in political theater
+
+(Wayne) Heavy industry: US Steel's Clairton plant had an explosion, at least one dead, several hurt, rescue ongoing. That plant's got a long history of fines and compliance troubles
+
+(Dr. House) If the building's been leaking warnings for years and someone lights a match, the diagnosis isn't "unlucky" -- it's neglect
+
+(Wayne) Weather beat: Tropical Storm Erin popped up west of Cabo Verde and is likely to spin into a hurricane, possibly intensifying rapidly. Models toss it east for now, maybe even toward the North Atlantic
+
+(Sheldon Cooper) Rapid intensification events are consistent with current climate baselines--warm water equals more energy. That's physics, not politics
+
+(Wayne) Markets are jittery ahead of CPI and this BLS chaos. Traders hate uncertainty--this is the perfect recipe to spike yields or tank mortgage rates depending on which way the wind blows
+
+(Tony Stark) If you break the clock everyone starts guessing the time and that's how you get a financial panic. You want stability? Stop politicizing the scoreboard
+
+(Wayne) And the small weirdness: two flashy crypto bros in Manhattan turned out to be part of a kidnapping racket. Clubs loved the drama until the cops did the math
+
+(Squirrely Dan) Wealth displays plus private security equals a cover story readers enjoy and victims do not
+
+(Wayne) Quick moral tally: troops in towns with falling crime, politicized stats, a summit that sidelines the party who actually lost land, journalists killed trying to report, civilians murdered in parking lots, detention records set by capacity, tech rollouts that trash livelihoods, industry deals that smell like extraction, and a storm that doesn't care about spin
+
+(Glen) Amen
+
+(Gail) That's my rant for today. Hit the buttons you hit when you want someone to be mildly inconvenienced or dramatically accountable.

--- a/user_text.txt
+++ b/user_text.txt
@@ -1,0 +1,90 @@
+(Wayne) How’re ya now
+(Daryl) Not so bad
+
+(Squirrely Dan) Guess what
+
+(Wayne) What
+
+(Squirrely Dan) The president just federalized D.C. police and flew in the National Guard like he’s doing a surprise open mic for authoritarian tendencies
+
+(Gail) He called it a “public safety emergency” and then handed the mic to federal agents—because nothing says local problem-solving like a thirty‑day executive temper tantrum
+
+(Stewart) It’s power theater for TV: declare an emergency, deploy troops, take credit for things that were improving already, and watch the opposition scramble to explain basic facts like “violent crime is down”
+
+(Sheldon Cooper) Fact: Washington’s violent crime has been trending downward; invoking the nineteen seventy-three Home Rule Act to seize local policing for thirty days is legally permissible but politically theatrical. Also statistically counterproductive as a stable policy signal
+
+(Tony Stark) It’s the same playbook — stage the crisis, sell the fix, cash the applause. If you want credibility, bring data. If you want headlines, bring boots
+
+(Wayne) Meanwhile the Bureau of Labor Statistics boss got canned after a soft jobs print and big revisions, and the president tapped a Heritage-linked economist to run the agency
+
+(Glen) Holy heck that sounds worryin’
+
+(Maddow) That’s not just turnover; it’s the weaponization of trust. The BLS is supposed to be independent. Replacing the commissioner after a bad headline and putting in a partisan pick makes markets and ordinary people doubt the numbers they live by
+
+(Dr. House) They didn’t fire a human error — they fired a scoreboard that didn’t flatter their team. Expect revisions, lawsuits, and a bonfire of credibility
+
+(Squirrely Dan) So now mortgage markets and pensions get to play roulette with what counts as “honest” data. That’ll be fun at Thanksgivinges
+
+(Wayne) Also on the globe tour of questionable choices, Dictator Donny is off to Alaska to meet Vlad the Realtor, without inviting Kyiv — and he’s already floating land swaps like he’s reading a real estate brochure to solve artillery problems
+
+(Sheldon Cooper) Excluding Ukraine from decisions about Ukrainian territory violates basic diplomatic norms and invites Europe to say “no deal.” Legitimacy requires the relevant sovereign to be at the table
+
+(Tony Stark) You cannot negotiate away someone else’s borders with a handshake and a stage set. If this summit has a goal, it’s optics — not peace
+
+(Wayne) And in the killing fields: five Al Jazeera journalists were just killed near al-Shifa in Gaza, including Anas al‑Sharif — the press got hit while trying to show the rest of us what’s happening
+
+(Maddow) Killing reporters is both a war crime risk and an attack on information. If the field reporters die, the fog of war becomes a curtain pulled over accountability
+
+(Stewart) You can’t bomb the witnesses and then demand applause for your version of events. That’s a script—badly written
+
+(Wayne) Back home: three people were shot dead in a Target parking lot in Austin. Suspect arrested, had documented mental‑health history; it’s the same grinding loop of violence and inadequate response
+
+(Dr. House) Thoughts, prayers, press cycle, repeat. Policy that changes outcomes? Not currently on the menu
+
+(Gail) Grief isn’t a stat to toss between headlines. It’s who’s left holding the cups
+
+(Wayne) ICE detention numbers shot past sixty thousand—record highs—because capacity is policy and capacity is pronouncing cruelty operational
+
+(Squirrely Dan) Build more beds, fill more beds, call it success. That’s logistics as heartless applause lines
+
+(Sheldon Cooper) Queueing theory note: increasing capacity without addressing inflow incentives increases throughput of suffering. Not complex; just morally bankrupt
+
+(Wayne) Tech corner: OpenAI pushed GPT‑Five live, yanked older models without warning, broke workflows, and then apologized — surprise product management horror show
+
+(Tony Stark) Feature flag, people. You don’t switch the platform core and expect businesses, creatives, and therapists who rely on previous models not to implode. Rookie shit at scale
+
+(Squirrely Dan) People lost their bespoke conversational bots and went shopping for competitors faster than you can say “rate limit”
+
+(Wayne) X’s Grok briefly suspended itself after spewing inappropriate replies. The bot’s still trying to see how far off the cliff it can go before someone slaps the wheel
+
+(Stewart) Silicon Valley keeps selling trust as a beta feature. Customers stop buying when the product stops being reliable or humane
+
+(Wayne) In industry politics, the administration cut a deal forcing a slice of chip sales to China and nudged Nvidia and AMD into a revenue commission. The market hated it, stocks dipped
+
+(Tony Stark) That’s state capitalism with a friendly smile: squeeze a cut for Treasury, hope supply doesn’t evaporate. Legal fights incoming, and Chinese buyers might simply turn elsewhere
+
+(Wayne) Harvard’s reportedly close to a massive settlement—half a billion to fund vocational programs—in exchange for federal funding restoration and fewer probes. Pay money, keep research grants; faculty are pissed
+
+(Maddow) That kind of deal normalizes leverage over academic independence. Universities become bargaining chips in political theater
+
+(Wayne) Heavy industry: US Steel’s Clairton plant had an explosion, at least one dead, several hurt, rescue ongoing. That plant’s got a long history of fines and compliance troubles
+
+(Dr. House) If the building’s been leaking warnings for years and someone lights a match, the diagnosis isn’t “unlucky” — it’s neglect
+
+(Wayne) Weather beat: Tropical Storm Erin popped up west of Cabo Verde and is likely to spin into a hurricane, possibly intensifying rapidly. Models toss it east for now, maybe even toward the North Atlantic
+
+(Sheldon Cooper) Rapid intensification events are consistent with current climate baselines—warm water equals more energy. That’s physics, not politics
+
+(Wayne) Markets are jittery ahead of CPI and this BLS chaos. Traders hate uncertainty—this is the perfect recipe to spike yields or tank mortgage rates depending on which way the wind blows
+
+(Tony Stark) If you break the clock everyone starts guessing the time and that’s how you get a financial panic. You want stability? Stop politicizing the scoreboard
+
+(Wayne) And the small weirdness: two flashy crypto bros in Manhattan turned out to be part of a kidnapping racket. Clubs loved the drama until the cops did the math
+
+(Squirrely Dan) Wealth displays plus private security equals a cover story readers enjoy and victims do not
+
+(Wayne) Quick moral tally: troops in towns with falling crime, politicized stats, a summit that sidelines the party who actually lost land, journalists killed trying to report, civilians murdered in parking lots, detention records set by capacity, tech rollouts that trash livelihoods, industry deals that smell like extraction, and a storm that doesn’t care about spin
+
+(Glen) Amen
+
+(Gail) That’s my rant for today. Hit the buttons you hit when you want someone to be mildly inconvenienced or dramatically accountable.

--- a/utils.py
+++ b/utils.py
@@ -100,21 +100,29 @@ def append_absolute_dates(
 def clean_text_for_tts(text: str) -> str:
     if not text:
         return ""
-    # 1. Remove URLs and <think> tags first, as they can contain complex characters.
+
+    # 1. Normalize special characters to their ASCII equivalents.
+    text = text.replace("’", "'")
+    text = text.replace("“", '"')
+    text = text.replace("”", '"')
+    text = text.replace("—", "--")
+    text = text.replace("‑", "-")
+
+    # 2. Remove URLs and <think> tags first, as they can contain complex characters.
     text = re.sub(r"http[s]?://\S+", "", text)
     text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
 
-    # 2. Define a whitelist of characters to keep.
+    # 3. Define a whitelist of characters to keep.
     # This includes letters (unicode), numbers, basic punctuation, and whitespace.
     # This is safer than a blacklist for preventing unknown "special characters".
     # \w includes unicode letters, numbers, and underscore.
     # We add common punctuation and the hyphen.
     allowed_chars = re.compile(r"[^\w\s.,!?'\"-]")
 
-    # 3. Remove all characters that are not in the whitelist.
+    # 4. Remove all characters that are not in the whitelist.
     text = allowed_chars.sub("", text)
 
-    # 4. Clean up excessive whitespace that might result from the substitution.
+    # 5. Clean up excessive whitespace that might result from the substitution.
     text = re.sub(r"\s+", " ", text).strip()
 
     return text


### PR DESCRIPTION
…non-ASCII characters like smart quotes, em-dashes, and non-breaking hyphens. This resulted in garbled or incomplete text being sent to the TTS engine.

This change adds a normalization step at the beginning of the function to replace these special characters with their standard ASCII equivalents before any other processing. This ensures that the text is correctly sanitized without losing content.