### PR TITLE
The `clean_text_for_tts` function had two issues:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ playwright-report/
 # Other
 .DS_Store
 Thumbs.db
+
+# Agent-generated temporary files
+user_text.txt
+cleaned_text.txt

--- a/utils.py
+++ b/utils.py
@@ -100,22 +100,31 @@ def append_absolute_dates(
 def clean_text_for_tts(text: str) -> str:
     if not text:
         return ""
-    # 1. Remove URLs and <think> tags first, as they can contain complex characters.
+
+    # 1. Normalize special characters to their ASCII equivalents.
+    text = text.replace("’", "'")
+    text = text.replace("“", '"')
+    text = text.replace("”", '"')
+    text = text.replace("—", "--")
+    text = text.replace("‑", "-")
+
+    # 2. Remove URLs and <think> tags first, as they can contain complex characters.
     text = re.sub(r"http[s]?://\S+", "", text)
     text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
 
-    # 2. Define a whitelist of characters to keep.
+    # 3. Define a whitelist of characters to keep.
     # This includes letters (unicode), numbers, basic punctuation, and whitespace.
     # This is safer than a blacklist for preventing unknown "special characters".
     # \w includes unicode letters, numbers, and underscore.
     # We add common punctuation and the hyphen.
     allowed_chars = re.compile(r"[^\w\s.,!?'\"-]")
 
-    # 3. Remove all characters that are not in the whitelist.
+    # 4. Remove all characters that are not in the whitelist.
     text = allowed_chars.sub("", text)
 
-    # 4. Clean up excessive whitespace that might result from the substitution.
-    text = re.sub(r"\s+", " ", text).strip()
+    # 5. Clean up excessive whitespace, preserving line breaks.
+    lines = [re.sub(r'[ \t]+', ' ', line).strip() for line in text.splitlines()]
+    text = '\n'.join(lines)
 
     return text
 


### PR DESCRIPTION
1. It used a whitelist that stripped out non-ASCII characters like smart quotes and em-dashes.
2. It collapsed all whitespace, including newlines, into single spaces, which destroyed the formatting of multi-line text.

This change introduces a two-part fix:
- A normalization step is added to replace special characters with their ASCII equivalents.
- The whitespace cleaning is modified to operate line-by-line, preserving newlines while still cleaning up excess spaces and tabs.

Additionally, this commit updates .gitignore to exclude temporary files generated during debugging.