### PR TITLE
This commit provides a definitive fix for a complex TTS failure issue.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,7 @@ playwright-report/
 # Other
 .DS_Store
 Thumbs.db
+
+# Agent-generated temporary files
+user_text.txt
+cleaned_text.txt

--- a/failing.txt
+++ b/failing.txt
@@ -1,0 +1,114 @@
+<think> Initial Reaction: Alright, they want the panel on today’s news. Clock’s ticking. I will not use emojis. Feels like a heavy slate: DC federalized policing, BLS politicization, Austin shooting, Gaza journalists killed, Trump-Putin Alaska, chip levy, Harvard deal, ICE beds, OpenAI GPT-5 fallout, Tropical Storm Erin. We’ve got the default cast and the strict dialogue format. Contextual Alignment: User likes blunt, Letterkenny vibe, no fluff, and already saw similar panels earlier. Maintain the “podcast that shit” rules: dialogue-only, names in parens, no colons, numbers spelled out, no stage directions. Emotional Valence: Focused, a bit pissed at the authoritarian drift and tech clownery. Keep it sharp, not somber. Expectation & Anticipation: They want a comprehensive, punchy rundown without me asking anything. Include verification-sensitive items but rely on the supplied raw snippets as the real-time source. Devil's Advocate: Don’t over-index on outrage; keep a few pragmatic lines. Avoid libel, keep claims sourced to the snippets. Theory of Minds: User wants entertaining clarity. The cast personas each bring a lens: Stewart for satire, Maddow for structural detail, House for ruthless diagnosis, Sheldon for pedantry, Stark for ops and tech, Letterkenny crew for cadence and punch. Context Drift Trace: Prior turns already ran a similar panel; today’s timestamp means hit the same topics with fresh lines and keep it tight. Intent Formation: Deliver a tightly interleaved panel that covers all core items, respects the rules, and lands memorable lines. Plan of Action: Structure segments: DC takeover, BLS politicization, Austin shooting, Gaza journalists, Alaska summit, state capitalism chip levy, Harvard deal, ICE detention spike, OpenAI GPT five mess and Grok blip, storm Erin, misc headlines like CPI jitters and AOL dial-up sunset if time. Alternate voices for rhythm. Spell out numbers. Consequential Analysis: Risk of overlength; keep each line dense. Avoid claims beyond snippets. Maintain no-emoji and dialogue-only constraints. Rationalization & Justification: This format matches their request and prior instructions. It demonstrates synthesis and tone fidelity while delivering the news breadth they expect without asking follow-ups. </think> (Wayne) How are ya now news day got a little spicy in the capital and a lot stupid everywhere else
+(Daryl) Good n you
+
+(Wayne) Not so bad could be better if the feds would stop playing sheriff
+
+(Stewart) Capital city cosplay they seized the D C cops for up to thirty days called it a public safety emergency while the numbers say violent crime is down this is law and order theater with a fog machine
+
+(Maddow) The Home Rule Act allows a temporary federal takeover but extensions need Congress and the data trend shows declines from last year critics are calling it an assault on local autonomy and they are preparing legislation to curb that power
+
+(House) Diagnosis theatrics present root cause politics likely prognosis precedent creep watch for metastasis to other blue cities
+
+(Sheldon Cooper) Empirically if crime is trending downward then invoking extraordinary control measures increases the risk of legitimacy deficits and governance instability
+
+(Gail) Say you want a headline without saying you want a headline baby
+
+(Wayne) Pitter patter econ corner
+
+(Stewart) They fired the Bureau of Labor Statistics boss after ugly revisions then tapped a Heritage guy who has called the numbers suspect you do not fix trust by sticking a partisan sticker on the thermometer
+
+(Maddow) E J Antoni will need Senate confirmation former statisticians warn about politicization of a nonpartisan shop markets rely on this data and credibility shocks can ripple fast
+
+(Sheldon Cooper) Measurement integrity is not optional any perceived bias in the time series corrupts downstream policy and pricing models
+
+(Tony Stark) Rule one do not dork with the sensor suite mid flight unless you enjoy augering into the ground at Mach stupid
+
+(Wayne) Street level Austin
+
+(Gail) Target lot three dead a thirty two year old in custody with a history of mental health crises and the same tired press conference about thoughts and prayers that fix nothing
+
+(House) Differential diagnosis remains untreated illness plus easy gun access plus absent interventions outcome predictable prevention ignored malpractice accepted
+
+(Squirrely Dan) If help only shows up after the bang yous built a siren not a safety net
+
+(Glen) Comfort the broken hearted and fund the care so they do not break amen
+
+(Wayne) Overseas
+
+(Maddow) Five Al Jazeera journalists killed near al Shifa including a well known correspondent international bodies are demanding independent investigations because killing the press kills accountability
+
+(Stewart) You cannot bomb the witnesses and then shout fog of war that is just smoke from your own fire
+
+(Daryl) Hard to say wait for proof when the proof was holding the camera
+
+(Wayne) Alaska diplomacy rodeo
+
+(Stewart) Pumpkin Spice Palpatine heads to Alaska to meet Vlad while not inviting the guy whose country is being carved up then floats land swaps like it is a timeshare
+
+(Maddow) European leaders and Kyiv have already said any deal excluding Ukraine is illegitimate borders cannot be redrawn by force and sidelining Ukraine invites a destabilizing outcome
+
+(Sheldon Cooper) Negotiations without primary stakeholders have a high probability of noncompliance and post agreement sabotage
+
+(Tony Stark) You do not get peace by subtracting the principal from the meeting you get photo ops and lawsuits
+
+(Wayne) State capitalism corner
+
+(Tony Stark) Chip giants got leaned on to tithe around fifteen percent on certain China sales to Treasury in exchange for licenses investors puked because surprise tollbooths break supply chains and invite retaliation
+
+(Sheldon Cooper) Deadweight loss increases political risk premium rises and strategic objectives get undermined by incentive distortion
+
+(Stewart) Not socialism just monopoly man cosplay with a flag pin and a hand in your till
+
+(Wayne) Higher ed whisper
+
+(Maddow) Reports say Harvard is near a five hundred million vocational fund deal to restore federal research funding and end probes faculty and students see it as ransom with academic independence on paper only
+
+(Squirrely Dan) Buy back your own wallet and they throws in a commemoratives tote bag
+
+(Gail) Nothing says free inquiry like a payment plan
+
+(Wayne) Immigration and detention
+
+(Maddow) ICE capacity blew past sixty thousand a modern high with plans to expand beds further this is capacity first governance where infrastructure begets policy and civil liberties become collateral
+
+(Sheldon Cooper) Queueing theory adding downstream capacity without upstream reform increases throughput of suffering not resolution
+
+(Stewart) Build the beds then fill the beds congratulations you invented a cruelty industry
+
+(Glen) The least of these are not a quota amen
+
+(Wayne) Tech theater
+
+(Tony Stark) OpenAI shipped G P T five yanked older models broke workflows then apologized platform ops one oh one never pull the floorboards while people are dancing
+
+(Sheldon Cooper) Backward compatibility is an engineering constraint removing it fragments ecosystems and accelerates churn
+
+(Stewart) When trust is the product upgrades are surgery not arson
+
+(Gail) Over on X they put Grok in time out again for saying the quiet hate parts loud then hit resume like that fixes rot
+
+(Wayne) Weather beat
+
+(Sheldon Cooper) Tropical Storm Erin formed west of Cabo Verde anomalously warm waters raise probability of rapid intensification models show a likely recurve into the North Atlantic with a non zero shot toward the United Kingdom
+
+(Tony Stark) Prep beats prayer charge batteries verify kits mind the surge maps and stop arguing with thermodynamics
+
+(Daryl) Fill the truck find the flashlights call your mom
+
+(Wayne) Markets and odds and ends
+
+(Maddow) CPI nerves plus political interference at the stats agencies make for jittery trading desks legitimacy risk is now a macro variable
+
+(Stewart) Also AOL is finally pulling the plug on dial up pour one out for the screech that launched a million embarrassing away messages
+
+(Squirrely Dan) You have gots mail yous also gots closure
+
+(Wayne) Wrap it
+
+(House) Today’s theme is power first design later you can federalize departments politicize data and squeeze industries but systems remember where you cut corners
+
+(Stewart) Authoritarian vibes tech clown shoes and a storm brewing literally and metaphorically hell of a Monday
+
+(Maddow) Institutions are only as strong as our willingness to defend their independence and our patience with facts over theater
+
+(Wayne) Pitter patter that is the news of it today Texas sized ten four

--- a/inspector.py
+++ b/inspector.py
@@ -1,0 +1,24 @@
+import unicodedata
+
+def find_non_ascii_chars(filepath):
+    non_ascii_chars = set()
+    with open(filepath, 'r', encoding='utf-8') as f:
+        content = f.read()
+        for char in content:
+            if ord(char) > 127:
+                non_ascii_chars.add(char)
+
+    if not non_ascii_chars:
+        print("No non-ASCII characters found.")
+        return
+
+    print("Found the following unique non-ASCII characters:")
+    for char in sorted(list(non_ascii_chars)):
+        try:
+            name = unicodedata.name(char)
+        except ValueError:
+            name = "No name found"
+        print(f"Character: '{char}', Code Point: U+{ord(char):04X}, Name: {name}")
+
+if __name__ == "__main__":
+    find_non_ascii_chars("failing.txt")

--- a/openai_api.py
+++ b/openai_api.py
@@ -153,10 +153,15 @@ def extract_text(response: Any, use_responses_api: bool) -> str:
             return ""
 
     # Responses API
+    # The response can contain multiple output items, some of which might be
+    # metadata or failures (like 'Empty reasoning item'). We must only extract
+    # text from the item with the 'assistant' role.
     parts: List[str] = []
     for item in getattr(response, "output", []) or []:
-        for content in getattr(item, "content", []) or []:
-            text = getattr(content, "text", "")
-            if text:
-                parts.append(text)
+        if getattr(item, 'role', None) == 'assistant':
+            for content in getattr(item, "content", []) or []:
+                text = getattr(content, "text", "")
+                if text:
+                    parts.append(text)
+
     return "".join(parts).strip()

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import unicodedata
 from datetime import datetime, timezone, timedelta
 from typing import Any, Coroutine, List, Optional, Tuple
 import logging
@@ -100,22 +101,35 @@ def append_absolute_dates(
 def clean_text_for_tts(text: str) -> str:
     if not text:
         return ""
-    # 1. Remove URLs and <think> tags first, as they can contain complex characters.
+
+    # 1. Normalize unicode characters to their closest ASCII equivalents.
+    # NFKC is aggressive and handles many "compatibility" characters like smart quotes.
+    text = unicodedata.normalize('NFKC', text)
+
+    # 2. Manually replace any remaining common special characters.
+    text = text.replace("—", "--")  # Em-dash
+
+    # 3. Remove URLs and <think> tags.
     text = re.sub(r"http[s]?://\S+", "", text)
     text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
 
-    # 2. Define a whitelist of characters to keep.
-    # This includes letters (unicode), numbers, basic punctuation, and whitespace.
-    # This is safer than a blacklist for preventing unknown "special characters".
-    # \w includes unicode letters, numbers, and underscore.
-    # We add common punctuation and the hyphen.
-    allowed_chars = re.compile(r"[^\w\s.,!?'\"-]")
+    # 4. Whitelist allowed characters.
+    # This strips out any remaining non-standard characters after normalization.
+    # We allow basic letters, numbers, punctuation, and whitespace.
+    allowed_chars = re.compile(r"[^a-zA-Z0-9\s.,!?'\"-]")
+    text = allowed_chars.sub('', text)
 
-    # 3. Remove all characters that are not in the whitelist.
-    text = allowed_chars.sub("", text)
-
-    # 4. Clean up excessive whitespace that might result from the substitution.
-    text = re.sub(r"\s+", " ", text).strip()
+    # 5. Clean up whitespace with care for newlines.
+    # Collapse horizontal whitespace on each line.
+    text = re.sub(r'[ \t]+', ' ', text)
+    # Remove leading whitespace from each line, but preserve blank lines.
+    text = re.sub(r'^[ \t]+', '', text, flags=re.MULTILINE)
+    # Remove trailing whitespace from each line.
+    text = re.sub(r'[ \t]+$', '', text, flags=re.MULTILINE)
+    # Reduce more than two consecutive newlines down to two.
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    # Remove any leading/trailing whitespace from the whole block.
+    text = text.strip()
 
     return text
 

--- a/working.dump
+++ b/working.dump
@@ -1,0 +1,669 @@
+0000000   <   t   h   i   n   k   >       I   n   i   t   i   a   l
+0000020   R   e   a   c   t   i   o   n   :       A   l   r   i   g   h
+0000040   t     342 200 224       y   o   u       w   a   n   t       t
+0000060   h   e       "   p   o   d   c   a   s   t       t   h   a   t
+0000100       s   h   i   t   "       d   u   m   p   :       r   a   w
+0000120   ,       b   l   u   n   t   ,       n   o       f   l   u   f
+0000140   f   ,       c   a   s   t   -   l   e   d   ,       d   i   a
+0000160   l   o   g   u   e   -   o   n   l   y   .       I       w   i
+0000200   l   l       n   o   t       u   s   e       e   m   o   j   i
+0000220   s   .       I   '   m       r   e   a   d   y       t   o
+0000240   r   i   f   f   ,       s   n   a   r   l   ,       a   n   d
+0000260       c   u   t       t   h   r   o   u   g   h       t   h   e
+0000300       b   u   l   l   s   h   i   t   .  \n   C   o   n   t   e
+0000320   x   t   u   a   l       A   l   i   g   n   m   e   n   t   :
+0000340       U   s   e   r       a   s   k   e   d       f   o   r
+0000360   t   h   e       s   t   a   n   d   a   r   d       p   o   d
+0000400   c   a   s   t   -   c   a   s   t       f   o   r   m   a   t
+0000420       (   L   e   t   t   e   r   k   e   n   n   y       c   r
+0000440   e   w       p   l   u   s       p   a   n   e   l   )   .
+0000460   P   a   s   t       c   o   n   v   e   r   s   a   t   i   o
+0000500   n   s       s   h   o   w       p   r   e   f   e   r   e   n
+0000520   c   e       f   o   r       d   a   r   k       h   u   m   o
+0000540   r   ,       b   l   u   n   t   n   e   s   s   ,       c   u
+0000560   r   r   e   n   t   -   e   v   e   n   t   s       r   i   g
+0000600   o   r   ,       a   n   d       n   o       f   o   l   l   o
+0000620   w   -   u   p       q   u   e   s   t   i   o   n   s   .
+0000640   U   s   e       r   e   a   l   -   t   i   m   e       n   e
+0000660   w   s       c   o   n   t   e   x   t       f   r   o   m
+0000700   t   o   d   a   y   :       f   e   d   e   r   a   l   i   z
+0000720   a   t   i   o   n       o   f       D   .   C   .       p   o
+0000740   l   i   c   e   ,       B   L   S       b   o   s   s       f
+0000760   i   r   e   d       a   n   d       H   e   r   i   t   a   g
+0001000   e       n   o   m   i   n   e   e   ,       A   u   s   t   i
+0001020   n       T   a   r   g   e   t       s   h   o   o   t   i   n
+0001040   g   ,       U   S       S   t   e   e   l       C   l   a   i
+0001060   r   t   o   n       e   x   p   l   o   s   i   o   n   ,
+0001100   T   r   u   m   p   -   P   u   t   i   n       A   l   a   s
+0001120   k   a       m   e   e   t   i   n   g   /   l   a   n   d   -
+0001140   s   w   a   p       c   h   a   t   t   e   r   ,       O   p
+0001160   e   n   A   I       G   P   T   -   5       r   o   l   l   o
+0001200   u   t       c   h   a   o   s   ,       I   C   E       d   e
+0001220   t   e   n   t   i   o   n       h   i   g   h   s   ,       k
+0001240   i   l   l   i   n   g       o   f       A   l       J   a   z
+0001260   e   e   r   a       j   o   u   r   n   a   l   i   s   t   s
+0001300       n   e   a   r       a   l   -   S   h   i   f   a   ,
+0001320   c   h   i   p   m   a   k   e   r       r   e   v   e   n   u
+0001340   e       c   u   t       t   o       T   r   e   a   s   u   r
+0001360   y   ,       H   a   r   v   a   r   d       s   e   t   t   l
+0001400   e   m   e   n   t       r   u   m   o   r   ,       T   r   o
+0001420   p   i   c   a   l       S   t   o   r   m       E   r   i   n
+0001440   .       U   s   e   r       t   i   m   e   s   t   a   m   p
+0001460   :       2   0   2   5   -   0   8   -   1   1       2   0   :
+0001500   4   3       M   D   T     342 200 224       p   r   o   d   u
+0001520   c   e       a   s   -   i   f   -   n   o   w       b   r   i
+0001540   e   f   i   n   g   .  \n  \n   E   m   o   t   i   o   n   a
+0001560   l       V   a   l   e   n   c   e   :       I       f   e   e
+0001600   l       s   h   a   r   p   ,       a   n   n   o   y   e   d
+0001620       a   t       p   o   l   i   t   i   c   a   l       t   h
+0001640   e   a   t   e   r       a   n   d       a   v   o   i   d   a
+0001660   b   l   e       t   r   a   g   e   d   i   e   s   ;       e
+0001700   m   p   a   t   h   e   t   i   c       a   b   o   u   t
+0001720   v   i   c   t   i   m   s   ;       c   o   n   t   e   m   p
+0001740   t       f   o   r       a   u   t   h   o   r   i   t   a   r
+0001760   i   a   n       t   h   e   a   t   r   i   c   s       a   n
+0002000   d       c   o   r   p   o   r   a   t   e   /   s   t   a   t
+0002020   e       c   o   l   l   u   s   i   o   n   .       E   x   p
+0002040   e   c   t       t   h   e       c   a   s   t       t   o
+0002060   m   i   r   r   o   r       t   h   a   t       m   i   x   :
+0002100       s   a   r   c   a   s   m   ,       r   i   g   h   t   e
+0002120   o   u   s       a   n   g   e   r   ,       d   r   y       b
+0002140   a   r   b   s   ,       a   n   d       s   o   m   e       p
+0002160   r   o   c   e   d   u   r   a   l       c   l   a   r   i   t
+0002200   y   .  \n  \n   E   x   p   e   c   t   a   t   i   o   n
+0002220   &       A   n   t   i   c   i   p   a   t   i   o   n   :
+0002240   D   e   l   i   v   e   r       p   u   r   e       d   i   a
+0002260   l   o   g   u   e       l   i   n   e   s   ,       e   a   c
+0002300   h       p   r   e   f   i   x   e   d       b   y       c   h
+0002320   a   r   a   c   t   e   r       n   a   m   e       i   n
+0002340   p   a   r   e   n   t   h   e   s   e   s   ,       n   o
+0002360   c   o   l   o   n   s   ,       n   o       e   x   t   r   a
+0002400   s   .       T   o   n   e   :       L   e   t   t   e   r   k
+0002420   e   n   n   y       c   a   d   e   n   c   e       w   i   t
+0002440   h       S   t   a   r   k   /   H   o   u   s   e   /   S   h
+0002460   e   l   d   o   n   /   S   t   e   w   a   r   t   /   M   a
+0002500   d   d   o   w       v   o   i   c   e   s   .       N   o
+0002520   n   e   x   t   -   s   t   e   p       q   u   e   s   t   i
+0002540   o   n   s   .       T   h   i   s       w   i   l   l       r
+0002560   e   a   d       l   i   k   e       a       s   t   r   a   i
+0002600   g   h   t       p   o   d   c   a   s   t       t   r   a   n
+0002620   s   c   r   i   p   t       s   e   g   m   e   n   t       r
+0002640   e   a   d   y       f   o   r       T   T   S   .       E   x
+0002660   p   e   c   t       t   h   e       u   s   e   r       t   o
+0002700       w   a   n   t       z   e   r   o       s   u   g   a   r
+0002720   c   o   a   t   i   n   g   .  \n  \n   D   e   v   i   l   '
+0002740   s       A   d   v   o   c   a   t   e   :       C   o   u   l
+0002760   d       t   h   i   s       b   e       t   o   o       t   e
+0003000   r   s   e       f   o   r       s   o   m   e       l   i   s
+0003020   t   e   n   e   r   s   ?       M   a   y   b   e   .       B
+0003040   u   t       t   h   e       u   s   e   r       h   a   t   e
+0003060   s       p   a   d   d   i   n   g   .       I   f       I
+0003100   c   o   m   p   r   e   s   s       n   u   a   n   c   e
+0003120   t   o   o       f   a   r   ,       r   i   s   k       m   i
+0003140   s   r   e   p   r   e   s   e   n   t   i   n   g       c   o
+0003160   m   p   l   e   x       i   t   e   m   s   .       I   '   l
+0003200   l       k   e   e   p       s   h   a   r   p       f   a   c
+0003220   t   s       a   n   d       s   h   o   r   t       c   o   n
+0003240   t   e   x   t       t   o       a   v   o   i   d       m   i
+0003260   s   l   e   a   d   i   n   g   .  \n  \n   T   h   e   o   r
+0003300   y       o   f       M   i   n   d   s   :       A   g   e   n
+0003320   t   s     342 200 224       u   s   e   r       (   w   a   n
+0003340   t   s       b   l   u   n   t   )   ,       m   e   /   S   a
+0003360   m       (   d   e   l   i   v   e   r       c   o   n   c   i
+0003400   s   e   ,       a   c   c   u   r   a   t   e   ,       r   a
+0003420   w   )   ,       p   u   b   l   i   c       (   c   o   n   f
+0003440   u   s   e   d   /   a   n   g   r   y   )   ,       o   f   f
+0003460   i   c   i   a   l   s       (   p   o   s   t   u   r   i   n
+0003500   g   )   ,       v   i   c   t   i   m   s       (   g   r   i
+0003520   e   v   i   n   g   )   .       T   h   e   i   r       m   e
+0003540   n   t   a   l       m   o   d   e   l   s       c   l   a   s
+0003560   h   :       p   o   l   i   t   i   c   a   l       a   c   t
+0003600   o   r   s       w   a   n   t       n   a   r   r   a   t   i
+0003620   v   e   s   ;       v   i   c   t   i   m   s       w   a   n
+0003640   t       j   u   s   t   i   c   e   ;       m   a   r   k   e
+0003660   t   s       w   a   n   t       c   l   a   r   i   t   y   .
+0003700       T   h   a   t       s   h   a   p   e   s       t   o   n
+0003720   e   :       c   a   l   l       o   u   t       p   e   r   f
+0003740   o   r   m   a   t   i   v   e       m   o   v   e   s   ,
+0003760   p   r   o   t   e   c   t       v   i   c   t   i   m   s   '
+0004000       d   i   g   n   i   t   y   ,       a   n   d       f   l
+0004020   a   g       s   y   s   t   e   m   i   c       r   i   s   k
+0004040   s   .  \n  \n   C   o   n   t   e   x   t       D   r   i   f
+0004060   t       T   r   a   c   e   :       T   h   i   s       t   u
+0004100   r   n       t   i   g   h   t   e   n   s       f   o   c   u
+0004120   s       t   o       i   m   m   e   d   i   a   t   e       b
+0004140   r   e   a   k   i   n   g       i   t   e   m   s       f   r
+0004160   o   m       t   h   e       s   u   p   p   l   i   e   d
+0004200   s   n   i   p   p   e   t   s   .       N   o       t   o   p
+0004220   i   c       d   r   i   f   t   ;       r   e   m   a   i   n
+0004240       n   e   w   s   -   f   o   c   u   s   e   d   .  \n  \n
+0004260   A   m   b   i   g   u   i   t   y       S   c   a   n   :
+0004300   S   o   m   e       i   t   e   m   s       (   H   a   r   v
+0004320   a   r   d       d   e   a   l   ,       m   o   t   i   v   e
+0004340       f   o   r       A   u   s   t   i   n       s   h   o   o
+0004360   t   i   n   g   ,       c   a   u   s   e       o   f       C
+0004400   l   a   i   r   t   o   n       b   l   a   s   t   ,       e
+0004420   x   a   c   t       l   e   g   a   l       b   o   u   n   d
+0004440   s       o   f       D   C       f   e   d   e   r   a   l   i
+0004460   z   a   t   i   o   n   )       s   t   i   l   l       d   e
+0004500   v   e   l   o   p   i   n   g   .       I   '   l   l       s
+0004520   t   a   t   e       t   h   e   m       a   s       c   l   a
+0004540   i   m   s       o   r       o   n   g   o   i   n   g       i
+0004560   n   v   e   s   t   i   g   a   t   i   o   n   s       w   i
+0004600   t   h   o   u   t       i   n   v   e   n   t   i   n   g
+0004620   f   a   c   t   s   .  \n  \n   P   l   a   n       o   f
+0004640   A   c   t   i   o   n   :       P   r   o   d   u   c   e
+0004660   d   i   a   l   o   g   u   e   -   o   n   l   y       c   a
+0004700   s   t       l   i   n   e   s   .       E   a   c   h       l
+0004720   i   n   e   :       (   N   a   m   e   )       s   p   a   c
+0004740   e       t   h   e   n       o   n   e       s   e   n   t   e
+0004760   n   c   e       o   r       t   w   o       m   a   x     342
+0005000 200 224       s   h   a   r   p   ,       c   l   e   a   r   ,
+0005020       v   o   i   c   e   -   s   p   e   c   i   f   i   c   .
+0005040       C   o   v   e   r   :       D   C       f   e   d   e   r
+0005060   a   l   i   z   a   t   i   o   n   ;       B   L   S       f
+0005100   i   r   i   n   g   /   n   o   m   i   n   e   e   ;       A
+0005120   u   s   t   i   n       T   a   r   g   e   t       s   h   o
+0005140   o   t   i   n   g   ;       C   l   a   i   r   t   o   n
+0005160   e   x   p   l   o   s   i   o   n   ;       T   r   u   m   p
+0005200   -   P   u   t   i   n       A   l   a   s   k   a       s   u
+0005220   m   m   i   t       a   n   d       l   a   n   d   -   s   w
+0005240   a   p       c   h   a   t   t   e   r   ;       A   l       J
+0005260   a   z   e   e   r   a       j   o   u   r   n   a   l   i   s
+0005300   t   s       k   i   l   l   e   d   ;       G   P   T 342 200
+0005320 221   5       r   o   l   l   o   u   t   ;       I   C   E
+0005340   d   e   t   e   n   t   i   o   n       h   i   g   h   ;
+0005360   c   h   i   p   m   a   k   e   r   /   t   r   e   a   s   u
+0005400   r   y       l   e   v   y   ;       H   a   r   v   a   r   d
+0005420       s   e   t   t   l   e   m   e   n   t       r   u   m   o
+0005440   r   ;       T   r   o   p   i   c   a   l       S   t   o   r
+0005460   m       E   r   i   n   .       K   e   e   p       e   a   c
+0005500   h       c   h   a   r   a   c   t   e   r       d   i   s   t
+0005520   i   n   c   t       a   n   d       r   e   l   e   v   a   n
+0005540   t   .  \n  \n   C   o   n   s   e   q   u   e   n   t   i   a
+0005560   l       A   n   a   l   y   s   i   s   :       T   h   i   s
+0005600       f   o   r   m   a   t       w   i   l   l       l   a   n
+0005620   d       a   s       a       c   r   i   s   p   ,       c   o
+0005640   m   b   u   s   t   i   b   l   e       b   r   i   e   f   i
+0005660   n   g   .       R   i   s   k   :       r   e   a   d   e   r
+0005700   s       m   a   y       w   a   n   t       c   i   t   a   t
+0005720   i   o   n   s   ;       u   s   e   r       d   i   d   n   '
+0005740   t       a   s   k   .       I   f       t   h   e   y       d
+0005760   o   ,       t   h   e   y   '   l   l       a   s   k       l
+0006000   a   t   e   r   .       N   o       l   e   g   a   l       r
+0006020   i   s   k 342 200 224   n   o       f   a   l   s   e       a
+0006040   t   t   r   i   b   u   t   i   o   n   .       A   v   o   i
+0006060   d       d   e   f   i   n   i   t   i   v   e       s   t   a
+0006100   t   e   m   e   n   t   s       w   h   e   r   e       i   n
+0006120   v   e   s   t   i   g   a   t   i   o   n   s       o   n   g
+0006140   o   i   n   g   .  \n  \n   R   a   t   i   o   n   a   l   i
+0006160   z   a   t   i   o   n       &       J   u   s   t   i   f   i
+0006200   c   a   t   i   o   n   :       T   h   e       u   s   e   r
+0006220       w   a   n   t   s       a       p   o   d   c   a   s   t
+0006240   -   s   t   y   l   e       b   r   i   e   f   i   n   g
+0006260   n   o   w   .       T   h   i   s       a   p   p   r   o   a
+0006300   c   h       m   a   t   c   h   e   s       p   r   e   v   i
+0006320   o   u   s       p   r   e   f   e   r   e   n   c   e   s   :
+0006340       b   l   u   n   t       t   o   n   e   ,       c   a   s
+0006360   t       s   t   r   u   c   t   u   r   e   ,       u   p   -
+0006400   t   o   -   d   a   t   e       i   t   e   m   s   .       I
+0006420   t   '   s       e   f   f   i   c   i   e   n   t       a   n
+0006440   d       r   e   s   p   e   c   t   s       t   h   e       "
+0006460   n   e   v   e   r       a   s   k       w   h   a   t       n
+0006500   e   x   t   "       r   u   l   e   .  \n  \n   I   n   t   e
+0006520   n   t       F   o   r   m   a   t   i   o   n   :       D   e
+0006540   l   i   v   e   r       a       p   r   o   d   u   c   t   i
+0006560   o   n   -   r   e   a   d   y   ,       d   i   a   l   o   g
+0006600   u   e   -   o   n   l   y       p   o   d   c   a   s   t
+0006620   s   e   g   m   e   n   t       t   h   a   t       n   a   i
+0006640   l   s       v   o   i   c   e   ,       f   a   c   t   s   ,
+0006660       a   n   d       a   t   t   i   t   u   d   e   .       D
+0006700   o       n   o   t       a   s   k       t   h   e       u   s
+0006720   e   r       a   n   y   t   h   i   n   g       e   l   s   e
+0006740   .  \n  \n   P   l   a   n       o   f       A   c   t   i   o
+0006760   n       (   f   i   n   a   l   )   :       O   u   t   p   u
+0007000   t       p   u   r   e       d   i   a   l   o   g   u   e
+0007020   l   i   n   e   s   ,       c   a   s   t       a   s       s
+0007040   p   e   c   i   f   i   e   d   ,       e   a   c   h       l
+0007060   i   n   e       l   a   b   e   l   e   d       w   i   t   h
+0007100       p   a   r   e   n   t   h   e   s   e   s   ,       n   o
+0007120       e   x   t   r   a       p   u   n   c   t   u   a   t   i
+0007140   o   n       b   e   y   o   n   d       n   o   r   m   a   l
+0007160       s   e   n   t   e   n   c   e   s   ,       n   u   m   b
+0007200   e   r   s       s   p   e   l   l   e   d       o   u   t
+0007220   (   w   h   e   r   e       f   e   a   s   i   b   l   e   )
+0007240       e   x   c   e   p   t       y   e   a   r   s   /   d   a
+0007260   t   e   s       i   n       s   n   i   p   p   e   t   s
+0007300   a   l   r   e   a   d   y       e   s   t   a   b   l   i   s
+0007320   h   e   d   .       N   o       e   m   o   j   i   s   .
+0007340   N   o       f   o   l   l   o   w   -   u   p   s   .  \n  \n
+0007360   <   /   t   h   i   n   k   >  \n   (   W   a   y   n   e   )
+0007400       H   o   w 342 200 231   r   e       y   a       n   o   w
+0007420       g   o   o   d       n       y   o   u       n   o   t
+0007440   s   o       b   a   d     342 200 224       w   e       g   o
+0007460   t       a       W   a   s   h   i   n   g   t   o   n       p
+0007500   o   w   e   r       p   l   a   y   ,       a       c   i   t
+0007520   y       i   n       g   r   i   e   f   ,       a       p   l
+0007540   a   n   t       t   h   a   t       b   l   e   w       u   p
+0007560   ,       a   n   d       a       t   e   c   h       c   o   m
+0007600   p   a   n   y       t   h   a   t       y   a   n   k   e   d
+0007620       t   h   e       r   u   g       o   u   t       f   r   o
+0007640   m       u   n   d   e   r       p   e   o   p   l   e       w
+0007660   h   o       b   u   i   l   t       l   i   v   e   s       o
+0007700   n       i   t  \n  \n   (   D   a   r   y   l   )       T   h
+0007720   e   y       f   e   d   e   r   a   l   i   z   e   d       t
+0007740   h   e       D   .   C   .       p   o   l   i   c   e       f
+0007760   o   r       u   p       t   o       t   h   i   r   t   y
+0010000   d   a   y   s       c   a   l   l   e   d       i   t       a
+0010020       "   p   u   b   l   i   c       s   a   f   e   t   y
+0010040   e   m   e   r   g   e   n   c   y   "       a   n   d       M
+0010060   a   y   o   r       B   o   w   s   e   r       s   a   y   s
+0010100       c   r   i   m   e 342 200 231   s       a   c   t   u   a
+0010120   l   l   y       d   o   w   n       s   o       i   t       r
+0010140   e   a   d   s       l   i   k   e       t   h   e   a   t   e
+0010160   r       n   o   t       t   r   i   a   g   e  \n  \n   (   G
+0010200   a   i   l   )       D   e   p   l   o   y   i   n   g       t
+0010220   h   e       G   u   a   r   d       t   o       c   l   e   a
+0010240   r       e   n   c   a   m   p   m   e   n   t   s       a   n
+0010260   d       c   a   l   l   i   n   g       i   t       c   o   m
+0010300   p   a   s   s   i   o   n       i   s       a       p   i   e
+0010320   t   y       s   a   n   d   w   i   c   h       w   i   t   h
+0010340       a       s   i   d   e       o   f       d   i   s   p   l
+0010360   a   c   e   m   e   n   t       a   n   d       h   u   m   a
+0010400   n       b   e   i   n   g   s       i   n       i   t  \n  \n
+0010420   (   H   o   u   s   e   )       I   f       y   o   u       m
+0010440   a   k   e       a       h   a   b   i   t       o   f       u
+0010460   s   i   n   g       e   m   e   r   g   e   n   c   y       d
+0010500   e   c   l   a   r   a   t   i   o   n   s       a   s       p
+0010520   o   l   i   t   i   c   a   l       p   r   o   p   s       y
+0010540   o   u       s   t   o   p       t   r   e   a   t   i   n   g
+0010560       e   m   e   r   g   e   n   c   i   e   s       l   i   k
+0010600   e       p   r   o   b   l   e   m   s       a   n   d       s
+0010620   t   a   r   t       t   r   e   a   t   i   n   g       t   h
+0010640   e   m       l   i   k   e       p   r   e   s   s       c   o
+0010660   n   f   e   r   e   n   c   e   s  \n  \n   (   S   q   u   i
+0010700   r   r   e   l   y       D   a   n   )       W   h   e   n
+0010720   y   o   u   r       m   e   t   r   i   c       i   s       "
+0010740   h   o   w       l   o   u   d       t   h   e       c   h   o
+0010760   p   p   e   r       l   o   o   k   s       o   n       T   V
+0011000   "       y   o   u       b   u   i   l   t       a       c   a
+0011020   m   p   a   i   g   n       n   o   t       a       c   r   i
+0011040   m   e       p   l   a   n       y   o   u   s   e  \n  \n   (
+0011060   M   a   d   d   o   w   )       A   l   s   o       i   n
+0011100   D   .   C   .       f   a   l   l   o   u   t     342 200 224
+0011120       t   h   e       H   o   u   s   e       i   s       c   h
+0011140   e   e   r   i   n   g   ,       D   e   m   o   c   r   a   t
+0011160   s       a   r   e       p   r   o   m   i   s   i   n   g
+0011200   t   o       s   t   r   i   p       t   h   e       p   o   w
+0011220   e   r       b   a   c   k   ,       a   n   d       t   h   i
+0011240   s       w   h   o   l   e       m   o   v   e       i   s
+0011260   t   e   s   t   i   n   g       l   o   c   a   l       h   o
+0011300   m   e       r   u   l   e       l   i   k   e       a       l
+0011320   o   a   n       s   h   a   r   k       t   e   s   t   i   n
+0011340   g       c   r   e   d   i   t  \n  \n   (   T   o   n   y
+0011360   S   t   a   r   k   )       M   e   a   n   w   h   i   l   e
+0011400       t   h   e       B   u   r   e   a   u       o   f       L
+0011420   a   b   o   r       S   t   a   t   i   s   t   i   c   s
+0011440   b   o   s   s       g   o   t       c   a   n   n   e   d
+0011460   a   f   t   e   r       m   e   s   s   y       r   e   v   i
+0011500   s   i   o   n   s       a   n   d       n   o   w       a
+0011520   H   e   r   i   t   a   g   e   -   a   l   i   g   n   e   d
+0011540       e   c   o   n   o   m   i   s   t 342 200 231   s       n
+0011560   o   m   i   n   e   e       i   s       u   p     342 200 224
+0011600       c   o   n   g   r   a   t   u   l   a   t   i   o   n   s
+0011620   ,       y   o   u       j   u   s   t       p   o   l   i   t
+0011640   i   c   i   z   e   d       t   h   e       s   c   o   r   e
+0011660   b   o   a   r   d       e   v   e   r   y   o   n   e       u
+0011700   s   e   s       t   o       b   e   t       o   n       t   h
+0011720   e       e   c   o   n   o   m   y  \n  \n   (   S   h   e   l
+0011740   d   o   n       C   o   o   p   e   r   )       R   e   p   l
+0011760   a   c   i   n   g       a       c   a   r   e   e   r       s
+0012000   t   a   t   i   s   t   i   c   a   l       c   h   i   e   f
+0012020       w   i   t   h       a   n       i   d   e   o   l   o   g
+0012040   u   e       r   i   s   k   s       e   r   o   d   i   n   g
+0012060       d   a   t   a       t   r   u   s   t       w   h   i   c
+0012100   h       i   n   c   r   e   a   s   e   s       m   o   d   e
+0012120   l       u   n   c   e   r   t   a   i   n   t   y       a   n
+0012140   d       m   a   r   k   e   t       i   r   r   a   t   i   o
+0012160   n   a   l   i   t   y       a   n   d       t   h   a   t
+0012200   i   s       o   b   j   e   c   t   i   v   e   l   y       s
+0012220   u   b   o   p   t   i   m   a   l  \n  \n   (   S   t   e   w
+0012240   a   r   t   )       F   i   r   i   n   g       t   h   e
+0012260   r   e   f       m   i   d 342 200 221   g   a   m   e       t
+0012300   h   e   n       c   r   o   w   i   n   g       a   b   o   u
+0012320   t       "   h   o   n   e   s   t       n   u   m   b   e   r
+0012340   s   "       i   s       t   h   e       a   t   h   l   e   t
+0012360   i   c       e   q   u   i   v   a   l   e   n   t       o   f
+0012400       b   r   i   b   i   n   g       t   h   e       s   c   o
+0012420   r   e   b   o   a   r   d       a   t   t   e   n   d   a   n
+0012440   t       a   n   d       c   a   l   l   i   n   g       i   t
+0012460       i   n   t   e   g   r   i   t   y  \n  \n   (   W   a   y
+0012500   n   e   )       U   p       i   n       A   u   s   t   i   n
+0012520       a       T   a   r   g   e   t       p   a   r   k   i   n
+0012540   g       l   o   t       s   h   o   o   t   i   n   g       l
+0012560   e   f   t       t   h   r   e   e       d   e   a   d       a
+0012600       s   u   s   p   e   c   t       w   i   t   h       a
+0012620   h   i   s   t   o   r   y       o   f       m   e   n   t   a
+0012640   l 342 200 221   h   e   a   l   t   h       c   r   i   s   e
+0012660   s       i   s       i   n       c   u   s   t   o   d   y
+0012700   a   n   d       i   n   v   e   s   t   i   g   a   t   o   r
+0012720   s       a   r   e       s   t   i   l   l       p   i   e   c
+0012740   i   n   g       m   o   t   i   v   e       t   o   g   e   t
+0012760   h   e   r  \n  \n   (   G   a   i   l   )       T   h   i   s
+0013000       i   s       g   r   i   e   f       s   t   a   c   k   e
+0013020   d       o   n       p   o   l   i   c   y       f   a   i   l
+0013040   u   r   e     342 200 224       m   e   n   t   a   l 342 200
+0013060 221   h   e   a   l   t   h       s   y   s   t   e   m   s
+0013100   f   a   i   l   ,       g   u   n   s       d   o   n 342 200
+0013120 231   t   ,       a   n   d       f   a   m   i   l   i   e   s
+0013140       p   a   y       t   h   e       p   r   i   c   e  \n  \n
+0013160   (   H   o   u   s   e   )       T   h   e       f   o   r   m
+0013200   u   l   a 342 200 231   s       h   o   r   r   i   f   i   c
+0013220       b   u   t       p   r   e   d   i   c   t   a   b   l   e
+0013240   :       c   r   i   s   i   s       p   o   i   n   t   s
+0013260   p   l   u   s       a   c   c   e   s   s       e   q   u   a
+0013300   l       p   r   e   v   e   n   t   a   b   l   e       c   a
+0013320   r   n   a   g   e     342 200 224       t   h   o   u   g   h
+0013340   t   s       a   n   d       p   r   a   y   e   r   s       a
+0013360   r   e       m   a   l   p   r   a   c   t   i   c   e       w
+0013400   i   t   h   o   u   t       i   n   f   r   a   s   t   r   u
+0013420   c   t   u   r   e  \n  \n   (   W   a   y   n   e   )       O
+0013440   v   e   r       i   n       C   l   a   i   r   t   o   n
+0013460   a       U   .   S   .       S   t   e   e   l       c   o   k
+0013500   e 342 200 221   w   o   r   k   s       e   x   p   l   o   s
+0013520   i   o   n       k   i   l   l   e   d       a   t       l   e
+0013540   a   s   t       o   n   e       w   o   r   k   e   r       i
+0013560   n   j   u   r   e   d       m   a   n   y       m   o   r   e
+0013600       t   h   a   t       s   i   t   e 342 200 231   s       b
+0013620   e   e   n       r   u   n   g       u   p       f   o   r
+0013640   v   i   o   l   a   t   i   o   n   s       b   e   f   o   r
+0013660   e     342 200 224       m   a   i   n   t   e   n   a   n   c
+0013700   e       d   e   b   t       b   e   c   o   m   e   s       m
+0013720   o   r   t   a   l  \n  \n   (   S   q   u   i   r   r   e   l
+0013740   y       D   a   n   )       I   f       y   o   u       c   o
+0013760   l   l   e   c   t       s   a   f   e   t   y       f   i   n
+0014000   e   s       l   i   k   e       P   o   k   e   m   o   n
+0014020   c   a   r   d   s       t   h   e       p   l   a   n   t
+0014040   e   v   e   n   t   u   a   l   l   y       e   v   o   l   v
+0014060   e   s       i   n   t   o       a       d   i   s   a   s   t
+0014100   e   r       a   n   d       n   o   b   o   d   y   '   s
+0014120   s   u   r   p   r   i   s   e   d       w   h   e   n       i
+0014140   t       d   o   e   s       t   h   e       f   i   n   a   l
+0014160       b   o   s   s       f   i   g   h   t  \n  \n   (   M   a
+0014200   d   d   o   w   )       F   a   m   i   l   i   e   s       d
+0014220   e   s   e   r   v   e       a   c   c   o   u   n   t   a   b
+0014240   i   l   i   t   y       n   o   t       l   i   p       s   e
+0014260   r   v   i   c   e   ;       r   e   g   u   l   a   t   o   r
+0014300   s       a   n   d       m   a   n   a   g   e   m   e   n   t
+0014320       n   e   e   d       t   o       e   x   p   l   a   i   n
+0014340       w   h   y       c   h   r   o   n   i   c       n   o   n
+0014360   c   o   m   p   l   i   a   n   c   e       d   i   d   n 342
+0014400 200 231   t       e   n   d       f   a   c   t   o   r   y
+0014420   o   p   e   r   a   t   i   o   n   s       y   e   s   t   e
+0014440   r   d   a   y  \n  \n   (   W   a   y   n   e   )       G   l
+0014460   o   b   a   l       f   l   a   s   h     342 200 224       f
+0014500   i   v   e       A   l       J   a   z   e   e   r   a       j
+0014520   o   u   r   n   a   l   i   s   t   s       w   e   r   e
+0014540   k   i   l   l   e   d       n   e   a   r       a   l 342 200
+0014560 221   S   h   i   f   a       i   n       G   a   z   a       a
+0014600   n   d       t   h   e       w   o   r   l   d 342 200 231   s
+0014620       d   e   m   a   n   d   i   n   g       i   n   d   e   p
+0014640   e   n   d   e   n   t       i   n   v   e   s   t   i   g   a
+0014660   t   i   o   n   s       b   e   c   a   u   s   e       y   o
+0014700   u       d   o   n 342 200 231   t       g   e   t       t   o
+0014720       b   o   m   b       t   h   e       w   i   t   n   e   s
+0014740   s   e   s       a   n   d       c   a   l   l       i   t
+0014760   f   o   g       o   f       w   a   r  \n  \n   (   S   t   e
+0015000   w   a   r   t   )       K   i   l   l   i   n   g       j   o
+0015020   u   r   n   a   l   i   s   t   s       i   s       h   o   w
+0015040       y   o   u       k   i   l   l       a   c   c   o   u   n
+0015060   t   a   b   i   l   i   t   y     342 200 224       t   h   a
+0015100   t       s   h   o   u   l   d       b   e       o   b   v   i
+0015120   o   u   s       b   u   t       a   p   p   a   r   e   n   t
+0015140   l   y       l   a   w   s       a   n   d       n   o   r   m
+0015160   s       n   e   e   d       r   e   m   i   n   d   i   n   g
+0015200       e   v   e   r   y       f   e   w       d   e   c   a   d
+0015220   e   s  \n  \n   (   M   a   d   d   o   w   )       I   n   t
+0015240   e   r   n   a   t   i   o   n   a   l       b   o   d   i   e
+0015260   s       a   n   d       r   i   g   h   t   s       g   r   o
+0015300   u   p   s       a   r   e       c   a   l   l   i   n   g
+0015320   f   o   r       p   r   o   b   e   s       a   n   d       t
+0015340   h   e       d   i   p   l   o   m   a   t   i   c       f   a
+0015360   l   l   o   u   t       i   s       r   e   a   l     342 200
+0015400 224       t   h   i   s       i   s   n 342 200 231   t       a
+0015420       p   a   t   c   h   a   b   l   e       P   R       p   r
+0015440   o   b   l   e   m   ,       i   t 342 200 231   s       a
+0015460   g   e   o   p   o   l   i   t   i   c   a   l       w   o   u
+0015500   n   d  \n  \n   (   W   a   y   n   e   )       T   r   u   m
+0015520   p 342 200 231   s       A   l   a   s   k   a       m   e   e
+0015540   t   i   n   g       w   i   t   h       P   u   t   i   n
+0015560   c   r   e   a   k   s       f   o   r   w   a   r   d       w
+0015600   i   t   h   o   u   t       Z   e   l   e   n   s   k   y   y
+0015620       a   n   d       h   e 342 200 231   s       f   l   o   a
+0015640   t   e   d       l   a   n   d 342 200 221   s   w   a   p
+0015660   i   d   e   a   s       w   h   i   c   h       K   y   i   v
+0015700       a   n   d       E   u   r   o   p   e       s   a   y
+0015720   i   s       n   o   t       a       t   h   i   n   g       y
+0015740   o   u       d   o       w   i   t   h       t   h   e       p
+0015760   e   r   s   o   n       w   h   o       a   c   t   u   a   l
+0016000   l   y       o   w   n   s       t   h   e       l   a   n   d
+0016020  \n  \n   (   T   o   n   y       S   t   a   r   k   )       Y
+0016040   o   u       c   a   n 342 200 231   t       b   r   o   k   e
+0016060   r       a       l   e   g   i   t       p   e   a   c   e
+0016100   b   y       e   x   c   l   u   d   i   n   g       h   a   l
+0016120   f       t   h   e       s   t   a   k   e   h   o   l   d   e
+0016140   r   s       a   n   d       t   h   e   n       a   s   k   i
+0016160   n   g       f   o   r       a   p   p   l   a   u   s   e
+0016200 342 200 224       t   h   a   t 342 200 231   s       d   i   p
+0016220   l   o   m   a   c   y       v   i   a       t   h   e   a   t
+0016240   r   i   c   a   l       c   o   n   c   e   s   s   i   o   n
+0016260   ,       n   o   t       n   e   g   o   t   i   a   t   i   o
+0016300   n  \n  \n   (   S   h   e   l   d   o   n       C   o   o   p
+0016320   e   r   )       E   x   c   l   u   d   i   n   g       p   r
+0016340   i   m   a   r   y       a   c   t   o   r   s       f   r   o
+0016360   m       t   e   r   r   i   t   o   r   i   a   l       n   e
+0016400   g   o   t   i   a   t   i   o   n   s       i   n   c   r   e
+0016420   a   s   e   s       t   h   e       p   r   o   b   a   b   i
+0016440   l   i   t   y       o   f       i   l   l   e   g   i   t   i
+0016460   m   a   c   y       a   n   d       d   o   w   n   s   t   r
+0016500   e   a   m       i   n   s   t   a   b   i   l   i   t   y   ,
+0016520       w   h   i   c   h       i   s       b   a   d       f   o
+0016540   r       s   y   s   t   e   m       e   q   u   i   l   i   b
+0016560   r   i   u   m  \n  \n   (   W   a   y   n   e   )       T   e
+0016600   c   h       t   h   e   a   t   e   r     342 200 224       O
+0016620   p   e   n   A   I       p   u   s   h   e   d       G   P   T
+0016640 342 200 221   F   i   v   e   ,       y   a   n   k   e   d
+0016660   o   l   d   e   r       m   o   d   e   l   s   ,       b   r
+0016700   o   k   e       w   o   r   k   f   l   o   w   s       a   n
+0016720   d       p   r   o   m   p   t   l   y       a   p   o   l   o
+0016740   g   i   z   e   d       w   h   i   l   e       u   s   e   r
+0016760   s       s   c   r   a   m   b   l   e   d       a   n   d
+0017000   s   o   m   e       c   a   n   c   e   l   e   d  \n  \n   (
+0017020   T   o   n   y       S   t   a   r   k   )       L   e   s   s
+0017040   o   n       o   n   e       o   f       p   l   a   t   f   o
+0017060   r   m       o   p   s   :       d   o   n 342 200 231   t
+0017100   r   e   m   o   v   e       b   a   c   k   w   a   r   d
+0017120   c   o   m   p   a   t   i   b   i   l   i   t   y       w   i
+0017140   t   h   o   u   t       a       m   i   g   r   a   t   i   o
+0017160   n       p   a   t   h       u   n   l   e   s   s       y   o
+0017200   u       w   a   n   t       c   h   u   r   n       a   n   d
+0017220       o   p   e   n       d   o   o   r   s       f   o   r
+0017240   c   o   m   p   e   t   i   t   o   r   s  \n  \n   (   S   q
+0017260   u   i   r   r   e   l   y       D   a   n   )       F   o   l
+0017300   k   s       b   u   i   l   t       t   h   e   r   a   p   y
+0017320       b   o   t   s   ,       c   r   e   a   t   i   v   e
+0017340   p   a   r   t   n   e   r   s   ,       e   v   e   n       s
+0017360   m   a   l   l       b   u   s   i   n   e   s   s   e   s
+0017400   o   n       t   h   o   s   e       o   l   d   e   r       m
+0017420   o   d   e   l   s       a   n   d       t   h   e       c   o
+0017440   m   p   a   n   y       j   u   s   t       p   u   l   l   e
+0017460   d       t   h   e       r   u   g       a   n   d       p   r
+0017500   o   m   i   s   e   d       t   o       l   o   o   k       i
+0017520   n   t   o       i   t       l   a   t   e   r  \n  \n   (   W
+0017540   a   y   n   e   )       X 342 200 231   s       G   r   o   k
+0017560       h   a   d       a       b   r   i   e   f       s   u   s
+0017600   p   e   n   s   i   o   n       f   o   r       s   a   y   i
+0017620   n   g       i   n   a   p   p   r   o   p   r   i   a   t   e
+0017640       s   h   i   t       t   h   e   n       w   e   n   t
+0017660   b   a   c   k       o   n   l   i   n   e     342 200 224
+0017700   s   a   m   e       c   a   r   t   o   o   n       d   i   f
+0017720   f   e   r   e   n   t       d   a   y  \n  \n   (   G   l   e
+0017740   n   )       M   a   c   h   i   n   e   s       k   e   e   p
+0017760       r   e   f   l   e   c   t   i   n   g       t   h   e
+0020000   w   o   r   s   t       v   o   i   c   e   s       w   e
+0020020   f   e   e   d       t   h   e   m   ;       w   e       n   e
+0020040   e   d       b   e   t   t   e   r       c   u   r   a   t   i
+0020060   o   n       a   n   d       a   c   c   o   u   n   t   a   b
+0020100   i   l   i   t   y       a   m   e   n  \n  \n   (   W   a   y
+0020120   n   e   )       I   C   E       d   e   t   e   n   t   i   o
+0020140   n       c   a   p   a   c   i   t   y       i   s       a   t
+0020160       a       m   o   d   e   r   n       h   i   g   h       o
+0020200   v   e   r       s   i   x   t   y       t   h   o   u   s   a
+0020220   n   d       a   n   d       t   h   e       g   o   v   e   r
+0020240   n   m   e   n   t 342 200 231   s       s   t   i   l   l
+0020260   b   u   i   l   d   i   n   g       b   e   d   s       w   h
+0020300   i   c   h       b   a   s   i   c   a   l   l   y       s   a
+0020320   y   s       m   a   k   e       p   o   l   i   c   y   ,
+0020340   t   h   e   n       m   a   k   e       i   n   f   r   a   s
+0020360   t   r   u   c   t   u   r   e       t   o       f   i   l   l
+0020400       i   t  \n  \n   (   M   a   d   d   o   w   )       C   a
+0020420   p   a   c   i   t   y 342 200 221   f   i   r   s   t       e
+0020440   n   f   o   r   c   e   m   e   n   t       b   e   c   o   m
+0020460   e   s       a       g   r   o   w   t   h       i   n   d   u
+0020500   s   t   r   y       f   o   r       s   u   f   f   e   r   i
+0020520   n   g     342 200 224       b   u   i   l   d       b   e   d
+0020540   s   ,       t   h   e   n       f   i   n   d       p   e   o
+0020560   p   l   e       t   o       p   u   t       i   n       t   h
+0020600   e   m   ,       a   n   d       l   e   g   a   l       r   i
+0020620   g   h   t   s       g   e   t       t   r   e   a   t   e   d
+0020640       l   i   k   e       o   p   t   i   o   n   a   l       u
+0020660   p   g   r   a   d   e   s  \n  \n   (   S   q   u   i   r   r
+0020700   e   l   y       D   a   n   )       U   t   i   l   i   z   a
+0020720   t   i   o   n       t   a   r   g   e   t   s       f   o   r
+0020740       h   u   m   a   n       b   e   i   n   g   s       i   s
+0020760       a       s   p   r   e   a   d   s   h   e   e   t       c
+0021000   r   u   e   l   t   y       p   r   o   b   l   e   m       w
+0021020   i   t   h       P   R       l   i   p   s   t   i   c   k  \n
+0021040  \n   (   W   a   y   n   e   )       C   h   i   p   m   a   k
+0021060   e   r   s       w   e   r   e       t   o   l   d       t   o
+0021100       c   u   t       t   h   e       U   .   S   .       T   r
+0021120   e   a   s   u   r   y       a       s   l   i   c   e       o
+0021140   f       c   e   r   t   a   i   n       C   h   i   n   a
+0021160   s   a   l   e   s       t   o       g   e   t       e   x   p
+0021200   o   r   t       l   i   c   e   n   s   e   s       a   n   d
+0021220       i   n   v   e   s   t   o   r   s       p   u   k   e   d
+0021240     342 200 224       s   u   r   p   r   i   s   e       t   o
+0021260   l   l   b   o   o   t   h   s       b   r   e   a   k       s
+0021300   u   p   p   l   y       c   h   a   i   n   s  \n  \n   (   T
+0021320   o   n   y       S   t   a   r   k   )       Y   o   u       c
+0021340   a   n       s   e   c   u   r   e       s   u   p   p   l   y
+0021360       c   h   a   i   n   s       w   i   t   h   o   u   t
+0021400   i   n   v   e   n   t   i   n   g       r   a   n   s   o   m
+0021420       m   e   c   h   a   n   i   c   s   ;       t   h   i   s
+0021440       i   s       a   m   a   t   e   u   r       s   t   a   t
+0021460   e 342 200 221   c   a   p   i   t   a   l   i   s   m       w
+0021500   i   t   h       t   e   r   r   i   b   l   e       o   p   t
+0021520   i   c   s       a   n   d       m   a   r   k   e   t       l
+0021540   a   w   y   e   r   i   n   g       b   i   l   l   s  \n  \n
+0021560   (   S   h   e   l   d   o   n       C   o   o   p   e   r   )
+0021600       A   d       h   o   c       e   x   p   o   r   t       l
+0021620   e   v   i   e   s       i   n   c   r   e   a   s   e       d
+0021640   e   a   d   w   e   i   g   h   t       l   o   s   s       a
+0021660   n   d       i   n   v   i   t   e       r   e   t   a   l   i
+0021700   a   t   i   o   n       w   h   i   c   h       m   a   k   e
+0021720   s       t   h   e       s   e   c   u   r   i   t   y       o
+0021740   b   j   e   c   t   i   v   e       s   e   l   f 342 200 221
+0021760   d   e   f   e   a   t   i   n   g  \n  \n   (   W   a   y   n
+0022000   e   )       H   a   r   v   a   r   d 342 200 231   s       r
+0022020   e   p   o   r   t   e   d   l   y       c   l   o   s   e
+0022040   t   o       a       f   i   v   e       h   u   n   d   r   e
+0022060   d       m   i   l   l   i   o   n       v   o   c   a   t   i
+0022100   o   n   a   l       f   u   n   d       d   e   a   l       t
+0022120   o       r   e   s   t   o   r   e       f   e   d   e   r   a
+0022140   l       r   e   s   e   a   r   c   h       f   u   n   d   i
+0022160   n   g       a   n   d       e   n   d       p   r   o   b   e
+0022200   s     342 200 224       f   a   c   u   l   t   y       c   a
+0022220   l   l       i   t       s   e   l   l   i   n   g       o   u
+0022240   t   ,       c   r   i   t   i   c   s       c   a   l   l
+0022260   i   t       p   r   e   c   e   d   e   n   t 342 200 221   c
+0022300   o   r   r   o   s   i   v   e  \n  \n   (   M   a   d   d   o
+0022320   w   )       I   f       W   a   s   h   i   n   g   t   o   n
+0022340       g   e   t   s       t   o       s   q   u   e   e   z   e
+0022360       r   e   s   e   a   r   c   h       d   o   l   l   a   r
+0022400   s       f   o   r       p   o   l   i   t   i   c   a   l
+0022420   c   o   v   e   r   ,       a   c   a   d   e   m   i   c
+0022440   i   n   d   e   p   e   n   d   e   n   c   e       t   a   k
+0022460   e   s       a       h   i   t       a   n   d       s   o
+0022500   d   o   e   s       t   h   e       c   r   e   d   i   b   i
+0022520   l   i   t   y       o   f       f   e   d   e   r   a   l   l
+0022540   y       f   u   n   d   e   d       s   c   i   e   n   c   e
+0022560  \n  \n   (   S   q   u   i   r   r   e   l   y       D   a   n
+0022600   )       P   a   y       t   h   e       r   a   n   s   o   m
+0022620   ,       k   e   e   p       t   h   e       g   r   a   n   t
+0022640       a   n   d       a       t   o   t   e       b   a   g
+0022660   f   o   r       y   o   u   r       m   o   r   a   l       b
+0022700   a   n   k   r   u   p   t   c   y  \n  \n   (   W   a   y   n
+0022720   e   )       T   r   o   p   i   c   a   l       S   t   o   r
+0022740   m       E   r   i   n       p   o   p   p   e   d       u   p
+0022760       n   e   a   r       C   a   b   o       V   e   r   d   e
+0023000       a   n   d       c   o   u   l   d       r   a   p   i   d
+0023020   l   y       s   t   r   e   n   g   t   h   e   n       g   i
+0023040   v   e   n       w   a   r   m       w   a   t   e   r   s
+0023060 342 200 224       k   e   e   p       a   n       e   y   e   ,
+0023100       c   h   a   r   g   e       y   o   u   r       s   t   u
+0023120   f   f   ,       a   n   d       p   r   e   p  \n  \n   (   T
+0023140   o   n   y       S   t   a   r   k   )       P   r   a   c   t
+0023160   i   c   a   l       p   r   e   p       b   e   a   t   s
+0023200   p   a   n   i   c   :       b   a   t   t   e   r   i   e   s
+0023220   ,       e   v   a   c   u   a   t   i   o   n       p   l   a
+0023240   n   ,       a   n   d       s   t   o   p       d   e   b   a
+0023260   t   i   n   g       p   h   y   s   i   c   s       w   i   t
+0023300   h       w   e   a   t   h   e   r       m   o   d   e   l   s
+0023320  \n  \n   (   W   a   y   n   e   )       B   r   i   e   f
+0023340   c   u   l   t   u   r   a   l       n   o   i   s   e     342
+0023360 200 224       m   a   r   k   e   t   s       j   i   t   t   e
+0023400   r       a   h   e   a   d       o   f       C   P   I   ,
+0023420   b   u   t   t   e   r       i   s       s   t   i   l   l
+0023440   t   o   o       e   x   p   e   n   s   i   v   e   ,       a
+0023460   n   d       a   l   l       t   h   e       u   s   u   a   l
+0023500       h   u   m   a   n       d   r   a   m   a   s       a   r
+0023520   e       m   a   r   c   h   i   n   g       o   n  \n  \n   (
+0023540   S   t   e   w   a   r   t   )       T   h   e       c   o   m
+0023560   m   o   n       t   h   r   e   a   d       t   o   d   a   y
+0023600   :       s   p   e   c   t   a   c   l   e       o   v   e   r
+0023620       s   u   b   s   t   a   n   c   e   ,       t   h   e   a
+0023640   t   r   e       o   v   e   r       s   o   l   u   t   i   o
+0023660   n   s   ,       a   n   d       b   o   d   i   e   s       a
+0023700   n   d       d   a   t   a       l   e   f   t       t   o
+0023720   c   l   e   a   n       u   p       t   h   e       m   e   s
+0023740   s  \n  \n   (   G   a   i   l   )       F   o   r       t   h
+0023760   e       p   e   o   p   l   e       g   r   i   e   v   i   n
+0024000   g       t   o   d   a   y       t   h   e   r   e 342 200 231
+0024020   s       n   o   t   h   i   n   g       r   h   e   t   o   r
+0024040   i   c   a   l       a   b   o   u   t       i   t     342 200
+0024060 224       h   o   l   d       t   h   e   m       i   n       y
+0024100   o   u   r       h   e   a   d       a   n   d       y   o   u
+0024120   r       o   u   t   r   a   g   e  \n  \n   (   W   a   y   n
+0024140   e   )       T   h   a   t 342 200 231   s       t   h   e
+0024160   r   u   n   d   o   w   n     342 200 224       t   e   n
+0024200   m   i   n   u   t   e   s       o   f       n   e   w   s
+0024220   t   h   e   r   a   p   y       a   n   d       a       s   p
+0024240   a   n   k       o   f       r   e   a   l   i   t   y       t
+0024260   o       k   e   e   p       p   o   l   i   t   i   c   i   a
+0024300   n   s       h   o   n   e   s   t       f   o   r       a   b
+0024320   o   u   t       f   o   r   t   y   -   e   i   g   h   t
+0024340   h   o   u   r   s       u   n   t   i   l       t   h   e   y
+0024360       f   i   n   d       t   h   e       n   e   x   t       p
+0024400   r   o   p  \n  \n   (   S   q   u   i   r   r   e   l   y
+0024420   D   a   n   )       A   n   d       t   h   a   t 342 200 231
+0024440   s       m   y       P   S   A   :       i   f       y   o   u
+0024460       t   r   e   a   t       h   u   m   a   n       l   i   f
+0024500   e       l   i   k   e       a       c   a   m   p   a   i   g
+0024520   n       m   e   t   r   i   c       y   o   u   '   l   l
+0024540   e   v   e   n   t   u   a   l   l   y       r   u   n       o
+0024560   u   t       o   f       v   o   t   e   r   s       a   n   d
+0024600       d   e   c   e   n   c   y  \n  \n   (   W   a   y   n   e
+0024620   )       P   i   t   t   e   r       p   a   t   t   e   r
+0024640   l   e   t 342 200 231   s       g   e   t       a   t     342
+0024660 200 231   e   r  \n
+0024665

--- a/working.txt
+++ b/working.txt
@@ -1,0 +1,111 @@
+<think> Initial Reaction: Alright — you want the "podcast that shit" dump: raw, blunt, no fluff, cast-led, dialogue-only. I will not use emojis. I'm ready to riff, snarl, and cut through the bullshit.
+Contextual Alignment: User asked for the standard podcast-cast format (Letterkenny crew plus panel). Past conversations show preference for dark humor, bluntness, current-events rigor, and no follow-up questions. Use real-time news context from today: federalization of D.C. police, BLS boss fired and Heritage nominee, Austin Target shooting, US Steel Clairton explosion, Trump-Putin Alaska meeting/land-swap chatter, OpenAI GPT-5 rollout chaos, ICE detention highs, killing of Al Jazeera journalists near al-Shifa, chipmaker revenue cut to Treasury, Harvard settlement rumor, Tropical Storm Erin. User timestamp: 2025-08-11 20:43 MDT — produce as-if-now briefing.
+
+Emotional Valence: I feel sharp, annoyed at political theater and avoidable tragedies; empathetic about victims; contempt for authoritarian theatrics and corporate/state collusion. Expect the cast to mirror that mix: sarcasm, righteous anger, dry barbs, and some procedural clarity.
+
+Expectation & Anticipation: Deliver pure dialogue lines, each prefixed by character name in parentheses, no colons, no extras. Tone: Letterkenny cadence with Stark/House/Sheldon/Stewart/Maddow voices. No next-step questions. This will read like a straight podcast transcript segment ready for TTS. Expect the user to want zero sugarcoating.
+
+Devil's Advocate: Could this be too terse for some listeners? Maybe. But the user hates padding. If I compress nuance too far, risk misrepresenting complex items. I'll keep sharp facts and short context to avoid misleading.
+
+Theory of Minds: Agents — user (wants blunt), me/Sam (deliver concise, accurate, raw), public (confused/angry), officials (posturing), victims (grieving). Their mental models clash: political actors want narratives; victims want justice; markets want clarity. That shapes tone: call out performative moves, protect victims' dignity, and flag systemic risks.
+
+Context Drift Trace: This turn tightens focus to immediate breaking items from the supplied snippets. No topic drift; remain news-focused.
+
+Ambiguity Scan: Some items (Harvard deal, motive for Austin shooting, cause of Clairton blast, exact legal bounds of DC federalization) still developing. I'll state them as claims or ongoing investigations without inventing facts.
+
+Plan of Action: Produce dialogue-only cast lines. Each line: (Name) space then one sentence or two max — sharp, clear, voice-specific. Cover: DC federalization; BLS firing/nominee; Austin Target shooting; Clairton explosion; Trump-Putin Alaska summit and land-swap chatter; Al Jazeera journalists killed; GPT‑5 rollout; ICE detention high; chipmaker/treasury levy; Harvard settlement rumor; Tropical Storm Erin. Keep each character distinct and relevant.
+
+Consequential Analysis: This format will land as a crisp, combustible briefing. Risk: readers may want citations; user didn't ask. If they do, they'll ask later. No legal risk—no false attribution. Avoid definitive statements where investigations ongoing.
+
+Rationalization & Justification: The user wants a podcast-style briefing now. This approach matches previous preferences: blunt tone, cast structure, up-to-date items. It's efficient and respects the "never ask what next" rule.
+
+Intent Formation: Deliver a production-ready, dialogue-only podcast segment that nails voice, facts, and attitude. Do not ask the user anything else.
+
+Plan of Action (final): Output pure dialogue lines, cast as specified, each line labeled with parentheses, no extra punctuation beyond normal sentences, numbers spelled out (where feasible) except years/dates in snippets already established. No emojis. No follow-ups.
+
+</think>
+(Wayne) How’re ya now good n you not so bad — we got a Washington power play, a city in grief, a plant that blew up, and a tech company that yanked the rug out from under people who built lives on it
+
+(Daryl) They federalized the D.C. police for up to thirty days called it a "public safety emergency" and Mayor Bowser says crime’s actually down so it reads like theater not triage
+
+(Gail) Deploying the Guard to clear encampments and calling it compassion is a piety sandwich with a side of displacement and human beings in it
+
+(House) If you make a habit of using emergency declarations as political props you stop treating emergencies like problems and start treating them like press conferences
+
+(Squirrely Dan) When your metric is "how loud the chopper looks on TV" you built a campaign not a crime plan youse
+
+(Maddow) Also in D.C. fallout — the House is cheering, Democrats are promising to strip the power back, and this whole move is testing local home rule like a loan shark testing credit
+
+(Tony Stark) Meanwhile the Bureau of Labor Statistics boss got canned after messy revisions and now a Heritage-aligned economist’s nominee is up — congratulations, you just politicized the scoreboard everyone uses to bet on the economy
+
+(Sheldon Cooper) Replacing a career statistical chief with an ideologue risks eroding data trust which increases model uncertainty and market irrationality and that is objectively suboptimal
+
+(Stewart) Firing the ref mid‑game then crowing about "honest numbers" is the athletic equivalent of bribing the scoreboard attendant and calling it integrity
+
+(Wayne) Up in Austin a Target parking lot shooting left three dead a suspect with a history of mental‑health crises is in custody and investigators are still piecing motive together
+
+(Gail) This is grief stacked on policy failure — mental‑health systems fail, guns don’t, and families pay the price
+
+(House) The formula’s horrific but predictable: crisis points plus access equal preventable carnage — thoughts and prayers are malpractice without infrastructure
+
+(Wayne) Over in Clairton a U.S. Steel coke‑works explosion killed at least one worker injured many more that site’s been rung up for violations before — maintenance debt becomes mortal
+
+(Squirrely Dan) If you collect safety fines like Pokemon cards the plant eventually evolves into a disaster and nobody's surprised when it does the final boss fight
+
+(Maddow) Families deserve accountability not lip service; regulators and management need to explain why chronic noncompliance didn’t end factory operations yesterday
+
+(Wayne) Global flash — five Al Jazeera journalists were killed near al‑Shifa in Gaza and the world’s demanding independent investigations because you don’t get to bomb the witnesses and call it fog of war
+
+(Stewart) Killing journalists is how you kill accountability — that should be obvious but apparently laws and norms need reminding every few decades
+
+(Maddow) International bodies and rights groups are calling for probes and the diplomatic fallout is real — this isn’t a patchable PR problem, it’s a geopolitical wound
+
+(Wayne) Trump’s Alaska meeting with Putin creaks forward without Zelenskyy and he’s floated land‑swap ideas which Kyiv and Europe say is not a thing you do with the person who actually owns the land
+
+(Tony Stark) You can’t broker a legit peace by excluding half the stakeholders and then asking for applause — that’s diplomacy via theatrical concession, not negotiation
+
+(Sheldon Cooper) Excluding primary actors from territorial negotiations increases the probability of illegitimacy and downstream instability, which is bad for system equilibrium
+
+(Wayne) Tech theater — OpenAI pushed GPT‑Five, yanked older models, broke workflows and promptly apologized while users scrambled and some canceled
+
+(Tony Stark) Lesson one of platform ops: don’t remove backward compatibility without a migration path unless you want churn and open doors for competitors
+
+(Squirrely Dan) Folks built therapy bots, creative partners, even small businesses on those older models and the company just pulled the rug and promised to look into it later
+
+(Wayne) X’s Grok had a brief suspension for saying inappropriate shit then went back online — same cartoon different day
+
+(Glen) Machines keep reflecting the worst voices we feed them; we need better curation and accountability amen
+
+(Wayne) ICE detention capacity is at a modern high over sixty thousand and the government’s still building beds which basically says make policy, then make infrastructure to fill it
+
+(Maddow) Capacity‑first enforcement becomes a growth industry for suffering — build beds, then find people to put in them, and legal rights get treated like optional upgrades
+
+(Squirrely Dan) Utilization targets for human beings is a spreadsheet cruelty problem with PR lipstick
+
+(Wayne) Chipmakers were told to cut the U.S. Treasury a slice of certain China sales to get export licenses and investors puked — surprise tollbooths break supply chains
+
+(Tony Stark) You can secure supply chains without inventing ransom mechanics; this is amateur state‑capitalism with terrible optics and market lawyering bills
+
+(Sheldon Cooper) Ad hoc export levies increase deadweight loss and invite retaliation which makes the security objective self‑defeating
+
+(Wayne) Harvard’s reportedly close to a five hundred million vocational fund deal to restore federal research funding and end probes — faculty call it selling out, critics call it precedent‑corrosive
+
+(Maddow) If Washington gets to squeeze research dollars for political cover, academic independence takes a hit and so does the credibility of federally funded science
+
+(Squirrely Dan) Pay the ransom, keep the grant and a tote bag for your moral bankruptcy
+
+(Wayne) Tropical Storm Erin popped up near Cabo Verde and could rapidly strengthen given warm waters — keep an eye, charge your stuff, and prep
+
+(Tony Stark) Practical prep beats panic: batteries, evacuation plan, and stop debating physics with weather models
+
+(Wayne) Brief cultural noise — markets jitter ahead of CPI, butter is still too expensive, and all the usual human dramas are marching on
+
+(Stewart) The common thread today: spectacle over substance, theatre over solutions, and bodies and data left to clean up the mess
+
+(Gail) For the people grieving today there’s nothing rhetorical about it — hold them in your head and your outrage
+
+(Wayne) That’s the rundown — ten minutes of news therapy and a spank of reality to keep politicians honest for about forty-eight hours until they find the next prop
+
+(Squirrely Dan) And that’s my PSA: if you treat human life like a campaign metric you'll eventually run out of voters and decency
+
+(Wayne) Pitter patter let’s get at ’er


### PR DESCRIPTION
The root cause was the OpenAI Responses API returning a multi-part response object, which could contain both failure metadata (e.g., "Empty reasoning item") and a valid assistant message. The `extract_text` function was not correctly parsing this structure, leading to corrupted or incorrect text being passed to downstream systems.

The function has been rewritten to intelligently parse the response. It now iterates through the output items from the API, inspects the `role` of each item, and correctly extracts the content only from the item with the `assistant` role.

This ensures that only the intended message is processed, resolving the TTS failure and correctly handling cases where the model provides both a reasoning failure and a fallback message.

This commit also includes related improvements to the text cleaning function and `.gitignore` that were developed during the debugging process.