### PR TITLE
Fix widespread ChromaDB memory issues in RAG and pruner

### DIFF
--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -579,9 +579,29 @@ async def retrieve_and_prepare_rag_context(
                 logger.debug(f"RAG: Collection '{name}' is not available for date-range search.")
                 continue
             try:
-                res = await asyncio.to_thread(coll.get, include=["documents", "metadatas"])
-                docs_with_ts: List[Tuple[str, datetime]] = []
-                if res and res.get("documents") and res.get("metadatas"):
+                # More efficient ChromaDB query with a 'where' filter for date range
+                where_filter = {
+                    "$and": [
+                        {"timestamp": {"$gte": start_iso}},
+                        {"timestamp": {"$lte": end_iso}},
+                    ]
+                }
+
+                # Determine max docs to fetch per collection type
+                max_docs_rss = getattr(config, "RAG_MAX_DATE_RANGE_DOCS", 100)
+                max_docs_other = getattr(config, "RAG_NUM_COLLECTION_DOCS_TO_FETCH", 3)
+                max_docs = max_docs_rss if name == "rss" else max_docs_other
+
+                res = await asyncio.to_thread(
+                    coll.get,
+                    where=where_filter,
+                    limit=max_docs, # Limit the results directly in the query
+                    include=["documents", "metadatas"]
+                )
+
+                if res and res.get("documents"):
+                    docs_with_ts = []
+                    # We still need to sort by timestamp since 'get' doesn't guarantee order
                     for doc_text, meta in zip(res["documents"], res["metadatas"]):
                         if not isinstance(doc_text, str) or not isinstance(meta, dict):
                             continue
@@ -590,25 +610,17 @@ async def retrieve_and_prepare_rag_context(
                             continue
                         try:
                             ts_dt = datetime.fromisoformat(ts)
-                            # If the datetime is timezone-aware, convert it to a naive local datetime
-                            # to allow comparison with the naive start_dt and end_dt.
                             if ts_dt.tzinfo is not None:
                                 ts_dt = ts_dt.astimezone().replace(tzinfo=None)
+                            docs_with_ts.append((doc_text, ts_dt))
                         except ValueError:
                             continue
-                        if start_dt <= ts_dt <= end_dt:
-                            docs_with_ts.append((doc_text, ts_dt))
-                if docs_with_ts:
+
+                    # Sort the retrieved documents by timestamp descending
                     docs_with_ts.sort(key=lambda x: x[1], reverse=True)
-                    max_docs_rss = getattr(config, "RAG_MAX_DATE_RANGE_DOCS", 100)
-                    max_docs_other = getattr(config, "RAG_NUM_COLLECTION_DOCS_TO_FETCH", 3)
-                    max_docs = max_docs_rss if name == "rss" else max_docs_other
-                    if len(docs_with_ts) > max_docs:
-                        logger.debug(
-                            f"RAG: Limiting '{name}' date-range docs from {len(docs_with_ts)} to {max_docs}."
-                        )
-                    limited_docs = docs_with_ts[:max_docs]
-                    for doc_text, _ in limited_docs:
+
+                    # The limit was already applied in the query, so no need to slice again
+                    for doc_text, _ in docs_with_ts:
                         truncated_doc = doc_text
                         if name == "chat_history":
                             max_chars = getattr(config, "RAG_MAX_FULL_CONVO_CHARS", 20000)
@@ -618,8 +630,9 @@ async def retrieve_and_prepare_rag_context(
                                     f"RAG: Truncated chat_history document from {len(doc_text)} to {max_chars} chars."
                                 )
                         retrieved_contexts_raw.append((truncated_doc, name))
+
                     logger.info(
-                        f"RAG: Retrieved {len(limited_docs)} '{name}' documents for date range {start_iso} to {end_iso}."
+                        f"RAG: Retrieved {len(docs_with_ts)} '{name}' documents for date range {start_iso} to {end_iso} using a where filter."
                     )
             except Exception as e_date:
                 logger.error(


### PR DESCRIPTION
This commit addresses critical memory overload issues caused by inefficient ChromaDB queries in multiple parts of the application.

1.  **`rag_chroma_manager.py`**: The date-range query in `retrieve_and_prepare_rag_context` was loading entire collections into memory. This has been fixed by using a `where` filter to perform the date filtering on the database side.

2.  **`timeline_pruner.py`**: The `_fetch_old_documents` function in the pruner was fetching the entire chat history collection into memory before filtering for old documents. This was the cause of the memory issue on "pruner startup". This has been replaced with an efficient `where` filter.

3.  **`timeline_pruner.py`**: The `_get_collection_timestamps` utility function was also optimized to only fetch metadata instead of full documents, reducing its memory footprint.

These changes ensure that the application handles large ChromaDB collections efficiently, preventing memory-related crashes during RAG retrieval and timeline pruning.