### PR TITLE
I've fixed the widespread ChromaDB memory issues in RAG and the pruner.

### DIFF
--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -578,35 +578,47 @@ async def retrieve_and_prepare_rag_context(
             if not coll:
                 logger.debug(f"RAG: Collection '{name}' is not available for date-range search.")
                 continue
+
             try:
-                res = await asyncio.to_thread(coll.get, include=["documents", "metadatas"])
+                # Memory-efficient batch processing for date-range queries
+                total = await asyncio.to_thread(coll.count)
                 docs_with_ts: List[Tuple[str, datetime]] = []
-                if res and res.get("documents") and res.get("metadatas"):
-                    for doc_text, meta in zip(res["documents"], res["metadatas"]):
+                limit = 200 # Process in batches to keep memory usage low
+
+                for offset in range(0, total, limit):
+                    batch = await asyncio.to_thread(
+                        coll.get,
+                        limit=limit,
+                        offset=offset,
+                        include=["documents", "metadatas"]
+                    )
+
+                    if not batch or not batch.get("documents") or not batch.get("metadatas"):
+                        continue
+
+                    for doc_text, meta in zip(batch["documents"], batch["metadatas"]):
                         if not isinstance(doc_text, str) or not isinstance(meta, dict):
                             continue
-                        ts = meta.get("timestamp")
-                        if not isinstance(ts, str):
+                        ts_str = meta.get("timestamp")
+                        if not isinstance(ts_str, str):
                             continue
+
                         try:
-                            ts_dt = datetime.fromisoformat(ts)
-                            # If the datetime is timezone-aware, convert it to a naive local datetime
-                            # to allow comparison with the naive start_dt and end_dt.
+                            ts_dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
                             if ts_dt.tzinfo is not None:
                                 ts_dt = ts_dt.astimezone().replace(tzinfo=None)
                         except ValueError:
                             continue
+
                         if start_dt <= ts_dt <= end_dt:
                             docs_with_ts.append((doc_text, ts_dt))
+
                 if docs_with_ts:
                     docs_with_ts.sort(key=lambda x: x[1], reverse=True)
                     max_docs_rss = getattr(config, "RAG_MAX_DATE_RANGE_DOCS", 100)
                     max_docs_other = getattr(config, "RAG_NUM_COLLECTION_DOCS_TO_FETCH", 3)
                     max_docs = max_docs_rss if name == "rss" else max_docs_other
-                    if len(docs_with_ts) > max_docs:
-                        logger.debug(
-                            f"RAG: Limiting '{name}' date-range docs from {len(docs_with_ts)} to {max_docs}."
-                        )
+
                     limited_docs = docs_with_ts[:max_docs]
                     for doc_text, _ in limited_docs:
                         truncated_doc = doc_text
@@ -614,9 +626,6 @@ async def retrieve_and_prepare_rag_context(
                             max_chars = getattr(config, "RAG_MAX_FULL_CONVO_CHARS", 20000)
                             if len(doc_text) > max_chars:
                                 truncated_doc = doc_text[-max_chars:]
-                                logger.debug(
-                                    f"RAG: Truncated chat_history document from {len(doc_text)} to {max_chars} chars."
-                                )
                         retrieved_contexts_raw.append((truncated_doc, name))
                     logger.info(
                         f"RAG: Retrieved {len(limited_docs)} '{name}' documents for date range {start_iso} to {end_iso}."
@@ -626,6 +635,7 @@ async def retrieve_and_prepare_rag_context(
                     f"RAG: Error retrieving date-filtered documents from '{name}': {e_date}",
                     exc_info=True,
                 )
+
         if not retrieved_contexts_raw:
             logger.info(
                 f"RAG: No documents found for date range {start_iso} to {end_iso} across any collection."

--- a/timeline_pruner.py
+++ b/timeline_pruner.py
@@ -38,58 +38,45 @@ def _fetch_old_documents(prune_days: int) -> List[Dict[str, Any]]:
             logger.info("No documents found in the chat history collection.")
             return []
 
-        logger.debug(f"Chat history collection has {total} documents. Beginning batch fetch.")
+        logger.debug(f"Chat history collection has {total} documents. Beginning batch processing.")
 
+        old_docs: List[Dict[str, Any]] = []
         limit = 100
-        ids: List[str] = []
-        docs: List[str] = []
-        metas: List[Dict[str, Any]] = []
+
         for offset in range(0, total, limit):
             batch = rcm.chat_history_collection.get(
                 limit=limit,
                 offset=offset,
                 include=["documents", "metadatas"],
             )
-            ids.extend(batch.get("ids", []))
-            docs.extend(batch.get("documents", []))
-            metas.extend(batch.get("metadatas", []))
 
-        if not ids:
-            logger.info("No documents found in the chat history collection after batching.")
-            return []
+            batch_ids = batch.get("ids", [])
+            batch_docs = batch.get("documents", [])
+            batch_metas = batch.get("metadatas", [])
 
-        logger.info(f"Fetched {len(ids)} total documents across all batches. Filtering in memory...")
+            for i, doc_id in enumerate(batch_ids):
+                meta = batch_metas[i] if i < len(batch_metas) else {}
+                doc_content = batch_docs[i] if i < len(batch_docs) else ""
+                ts_val = meta.get("timestamp") or meta.get("create_time")
 
-        old_docs: List[Dict[str, Any]] = []
-        for i, doc_id in enumerate(ids):
-            meta = metas[i] if i < len(metas) else {}
-            doc_content = docs[i] if i < len(docs) else ""
-
-            # Some imports store timestamps under 'create_time'. Check both
-            ts_val = meta.get("timestamp") or meta.get("create_time")
-
-            try:
-                if isinstance(ts_val, (int, float)):
-                    ts = datetime.fromtimestamp(ts_val)
-                elif isinstance(ts_val, str):
-                    # Handle common ISO formats. If parsing fails, fall back to None.
-                    ts = datetime.fromisoformat(ts_val.replace("Z", "+00:00"))
-                else:
+                try:
+                    if isinstance(ts_val, (int, float)):
+                        ts = datetime.fromtimestamp(ts_val)
+                    elif isinstance(ts_val, str):
+                        ts = datetime.fromisoformat(ts_val.replace("Z", "+00:00"))
+                    else:
+                        ts = None
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        "Could not convert timestamp '%s' for document ID %s. Error: %s. Skipping.",
+                        ts_val, doc_id, e
+                    )
                     ts = None
-            except (ValueError, TypeError) as e:
-                logger.warning(
-                    "Could not convert timestamp '%s' for document ID %s. Error: %s. Skipping.",
-                    ts_val,
-                    doc_id,
-                    e,
-                )
-                ts = None
 
-            # We filtered in Python, but double-check just in case:
-            if ts and ts <= cutoff_date:
-                old_docs.append({"id": doc_id, "document": doc_content, "metadata": meta, "timestamp": ts})
+                if ts and ts <= cutoff_date:
+                    old_docs.append({"id": doc_id, "document": doc_content, "metadata": meta, "timestamp": ts})
 
-        logger.info(f"Found {len(old_docs)} documents meeting the prune criteria after in-memory filtering.")
+        logger.info(f"Found {len(old_docs)} documents meeting the prune criteria after processing all batches.")
         return old_docs
 
     except Exception as e:
@@ -181,7 +168,7 @@ def print_collection_metrics() -> None:
         ("Relation", rcm.relation_collection),
         ("Observation", rcm.observation_collection),
     ]
-    
+
     logger.info("--- ChromaDB Collection Metrics ---")
 
     for name, coll_instance in collections_to_check:  # Renamed 'coll' to 'coll_instance'


### PR DESCRIPTION
My changes address the critical memory overload issues, which were caused by inefficient ChromaDB queries that attempted to load entire collections into memory. An initial attempt I made using a `where` filter was incorrect, as the existing data uses ISO-formatted timestamp strings which are not supported for numeric comparison operators in ChromaDB.

I then implemented a more robust solution by processing collections in small, memory-efficient batches:

1.  **`rag_chroma_manager.py`**: I updated the date-range query in `retrieve_and_prepare_rag_context` to iterate through collections in batches. This filters for relevant documents without loading the entire collection into memory.

2.  **`timeline_pruner.py`**: I applied the same batch-processing technique to the `_fetch_old_documents` function in the pruner, which resolves the memory issue during its startup.

These changes ensure that the application handles large ChromaDB collections efficiently, preventing memory-related crashes during RAG retrieval and timeline pruning, while remaining compatible with the existing data schema.