### PR TITLE
I've refactored the `alltweets` command to reuse a single browser ses…

### DIFF
--- a/discord_commands.py
+++ b/discord_commands.py
@@ -9,6 +9,7 @@ import asyncio
 from typing import Any, Optional, List  # Keep existing imports
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+from playwright.async_api import async_playwright
 
 # Bot services and utilities
 from config import config
@@ -669,6 +670,7 @@ async def process_twitter_user(
     interaction: discord.Interaction,
     username: str,
     limit: int,
+    page: Optional[Any] = None,
 ) -> bool:
     """Fetch, summarize and display recent tweets from a single user.
 
@@ -680,6 +682,8 @@ async def process_twitter_user(
         Twitter username to process.
     limit : int
         Maximum number of tweets to fetch.
+    page : Optional[Any], optional
+        An existing Playwright page to reuse, by default ``None``.
 
     Returns
     -------
@@ -719,7 +723,7 @@ async def process_twitter_user(
         user_seen_tweet_ids = all_seen_tweet_ids_cache.get(clean_username, set())
 
         fetched_tweets_data = await scrape_latest_tweets(
-            clean_username, limit=limit, progress_callback=send_progress
+            clean_username, limit=limit, progress_callback=send_progress, page=page
         )
 
         if not fetched_tweets_data:
@@ -2525,68 +2529,103 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             return
 
         scrape_lock = bot_state_instance.get_scrape_lock()
-        queue_notice = scrape_lock.locked()
-        acquired_lock = False
-        if queue_notice:
+        if scrape_lock.locked():
             await interaction.response.send_message(
                 "Waiting for other scraping tasks to finish before fetching tweets...",
                 ephemeral=True,
             )
-            await scrape_lock.acquire()
-            acquired_lock = True
-            await interaction.followup.send(content="Starting to scrape tweets from default accounts...")
-        else:
-            await scrape_lock.acquire()
-            acquired_lock = True
+
+        playwright = None
+        context = None
+        browser = None
+        page = None
+
+        async with scrape_lock:
             await interaction.response.defer(ephemeral=False)
             await interaction.followup.send(content="Starting to scrape tweets from default accounts...")
 
-        try:
-            any_new = False
-            for username in DEFAULT_TWITTER_USERS:
-                processed = await process_twitter_user(interaction, username, limit)
-                any_new = any_new or processed
-
-            if not any_new:
-                await safe_followup_send(
-                    interaction,
-                    content="No new tweets found for any default account.",
-                    ephemeral=True,
-                )
-
-            user_msg = MsgNode("user", f"/alltweets (limit {limit})", name=str(interaction.user.id))
-            assistant_msg = MsgNode(
-                "assistant",
-                "Finished fetching tweets from default accounts.",
-                name=str(bot_instance.user.id),
-            )
-            await bot_state_instance.append_history(interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY)
-            await bot_state_instance.append_history(interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY)
-            progress_note = None
             try:
-                progress_note = await interaction.followup.send(
-                    content="\U0001F501 Post-processing...", ephemeral=True
-                )
-            except discord.HTTPException:
-                progress_note = None
+                playwright = await async_playwright().start()
 
-            start_post_processing_task(
-                ingest_conversation_to_chromadb(
-                    llm_client_instance,
-                    interaction.channel_id,
-                    interaction.user.id,
-                    [user_msg, assistant_msg],
-                    None,
-                ),
-                progress_message=progress_note,
-            )
-        except Exception as e:
-            logger.error(f"Error in alltweets_slash_command: {e}", exc_info=True)
-            await interaction.followup.send(content=f"Failed to process tweets. Error: {str(e)[:500]}")
-        finally:
-            if acquired_lock:
-                scrape_lock.release()
-                logger.debug("Scrape lock released for /alltweets")
+                user_data_dir = os.path.join(os.getcwd(), ".pw-profile")
+                profile_dir_usable = True
+                if not os.path.exists(user_data_dir):
+                    try:
+                        os.makedirs(user_data_dir, exist_ok=True)
+                    except OSError:
+                        profile_dir_usable = False
+                        logger.error("Could not create .pw-profile. Using non-persistent context for alltweets.")
+
+                if profile_dir_usable:
+                    context = await playwright.chromium.launch_persistent_context(
+                        user_data_dir, headless=config.HEADLESS_PLAYWRIGHT,
+                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                        user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36",
+                        slow_mo=150
+                    )
+                else:
+                    browser = await playwright.chromium.launch(
+                        headless=config.HEADLESS_PLAYWRIGHT,
+                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                        slow_mo=150
+                    )
+                    context = await browser.new_context(
+                        user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
+                    )
+
+                page = await context.new_page()
+
+                any_new = False
+                for username in DEFAULT_TWITTER_USERS:
+                    processed = await process_twitter_user(interaction, username, limit, page=page)
+                    any_new = any_new or processed
+
+                if not any_new:
+                    await safe_followup_send(
+                        interaction,
+                        content="No new tweets found for any default account.",
+                        ephemeral=True,
+                    )
+
+                user_msg = MsgNode("user", f"/alltweets (limit {limit})", name=str(interaction.user.id))
+                assistant_msg = MsgNode(
+                    "assistant",
+                    "Finished fetching tweets from default accounts.",
+                    name=str(bot_instance.user.id),
+                )
+                await bot_state_instance.append_history(interaction.channel_id, user_msg, config.MAX_MESSAGE_HISTORY)
+                await bot_state_instance.append_history(interaction.channel_id, assistant_msg, config.MAX_MESSAGE_HISTORY)
+                progress_note = None
+                try:
+                    progress_note = await interaction.followup.send(
+                        content="\U0001F501 Post-processing...", ephemeral=True
+                    )
+                except discord.HTTPException:
+                    progress_note = None
+
+                start_post_processing_task(
+                    ingest_conversation_to_chromadb(
+                        llm_client_instance,
+                        interaction.channel_id,
+                        interaction.user.id,
+                        [user_msg, assistant_msg],
+                        None,
+                    ),
+                    progress_message=progress_note,
+                )
+            except Exception as e:
+                logger.error(f"Error in alltweets_slash_command: {e}", exc_info=True)
+                await interaction.followup.send(content=f"Failed to process tweets. Error: {str(e)[:500]}")
+            finally:
+                if page and not page.is_closed():
+                    await page.close()
+                if context:
+                    await context.close()
+                if browser:
+                    await browser.close()
+                if playwright:
+                    await playwright.stop()
+                logger.debug("Playwright session for /alltweets closed.")
 
 
     @bot_instance.tree.command(name="groundnews", description="Scrapes Ground News 'My Feed' and summarizes new articles.")

--- a/web_utils.py
+++ b/web_utils.py
@@ -349,143 +349,189 @@ async def scrape_website(
     finally:
         await _graceful_close_playwright(page, context_manager, browser_instance_sw, profile_dir_usable)
 
-async def scrape_latest_tweets(username_queried: str, limit: int = 20, progress_callback: Optional[Callable[[str], Awaitable[None]]] = None) -> List[TweetData]:
-    logger.info(f"Scraping last {limit} tweets for @{username_queried} (profile page, with replies) using Playwright JS execution.")
+async def _scrape_twitter_page(
+    page: Any,
+    username_queried: str,
+    limit: int,
+    progress_callback: Optional[Callable[[str], Awaitable[None]]],
+    tweets_collected: List[TweetData],
+    seen_tweet_ids: Set[str],
+) -> None:
+    """Helper to scrape tweets from an already-initialized Playwright page."""
+    url = f"https://x.com/{username_queried.lstrip('@')}/with_replies"
+    logger.info(f"Navigating to Twitter profile: {url}")
+    await page.goto(url, timeout=60000, wait_until="domcontentloaded")
+
+    try:
+        await page.wait_for_selector("article[data-testid='tweet']", timeout=30000)
+        logger.info("Initial tweet articles detected on page.")
+    except PlaywrightTimeoutError:
+        logger.warning(
+            f"Timed out waiting for initial tweet articles for @{username_queried}. Page might be empty or blocked."
+        )
+        return
+
+    max_scroll_attempts = limit + 15
+    for scroll_attempt in range(max_scroll_attempts):
+        if len(tweets_collected) >= limit:
+            break
+
+        try:
+            clicked_count = await page.evaluate(JS_EXPAND_SHOWMORE_TWITTER, 5)
+            if clicked_count > 0:
+                logger.info(f"Clicked {clicked_count} 'Show more' elements on Twitter page.")
+                await asyncio.sleep(random.uniform(0.5, 2.0))
+        except PlaywrightTimeoutError:
+            logger.warning(f"Timeout during JS 'Show More' execution for @{username_queried}.")
+        except Exception as e_sm:
+            logger.warning(f"JavaScript 'Show More' execution error: {e_sm}")
+
+        extracted_this_round: List[Dict[str, Any]] = []
+        newly_added_count = 0
+        try:
+            extracted_this_round = await page.evaluate(JS_EXTRACT_TWEETS_TWITTER)
+        except PlaywrightTimeoutError:
+            logger.warning(f"Timeout during JS tweet extraction for @{username_queried}.")
+        except Exception as e_js:
+            logger.error(f"JavaScript tweet extraction error: {e_js}")
+
+        for data in extracted_this_round:
+            uid_parts = [
+                str(data.get('id', '')),
+                str(data.get("username", "")),
+                str(data.get("content") or "")[:30],
+                str(data.get("timestamp", "")),
+            ]
+            uid = hashlib.md5("".join(filter(None, uid_parts)).encode('utf-8')).hexdigest()
+
+            if uid and uid not in seen_tweet_ids:
+                tweet = TweetData(
+                    id=data.get('id', ''),
+                    username=data.get('username', 'unknown_user'),
+                    content=data.get('content', ''),
+                    timestamp=data.get('timestamp', ''),
+                    tweet_url=data.get('tweet_url', ''),
+                    is_repost=data.get('is_repost', False),
+                    reposted_by=data.get('reposted_by'),
+                    image_urls=data.get('image_urls', []),
+                    alt_texts=data.get('alt_texts', []),
+                )
+                tweets_collected.append(tweet)
+                seen_tweet_ids.add(uid)
+                newly_added_count += 1
+                if progress_callback:
+                    try:
+                        await progress_callback(
+                            f"Scraped {len(tweets_collected)}/{limit} tweets for @{username_queried}..."
+                        )
+                    except Exception as e_cb:
+                        logger.warning(f"Progress callback error: {e_cb}")
+                if len(tweets_collected) >= limit:
+                    break
+
+        if newly_added_count == 0 and scroll_attempt > (limit // 2 + 7):
+            logger.info("No new unique tweets found in several scroll attempts. Stopping.")
+            if progress_callback:
+                await progress_callback(
+                    f"Stopping early: No new unique tweets found after {scroll_attempt + 1} scrolls. Collected {len(tweets_collected)}."
+                )
+            break
+
+        try:
+            await page.evaluate("window.scrollBy(0, window.innerHeight * 1);")
+            await asyncio.sleep(random.uniform(0.5, 2.0))
+        except PlaywrightTimeoutError:
+            logger.warning(
+                f"Timeout during page scroll for @{username_queried}. Assuming end of content or page issue."
+            )
+            break
+
+
+async def scrape_latest_tweets(
+    username_queried: str,
+    limit: int = 20,
+    progress_callback: Optional[Callable[[str], Awaitable[None]]] = None,
+    page: Optional[Any] = None,
+) -> List[TweetData]:
+    """Scrape latest tweets, optionally reusing an existing Playwright page."""
+    logger.info(
+        f"Scraping last {limit} tweets for @{username_queried} using Playwright."
+    )
     tweets_collected: List[TweetData] = []
     seen_tweet_ids: set[str] = set()
 
-    user_data_dir = os.path.join(os.getcwd(), ".pw-profile")
-    profile_dir_usable = True
-    if not os.path.exists(user_data_dir):
-        try:
-            os.makedirs(user_data_dir, exist_ok=True)
-        except OSError:
-            profile_dir_usable = False
-            logger.error("Could not create .pw-profile. Using non-persistent context for tweet scraping.")
-
-    context_manager: Optional[Any] = None
-    browser_instance_st: Optional[Any] = None
-    page: Optional[Any] = None
-    try:
-        async with PLAYWRIGHT_SEM:
-            async with async_playwright() as p:
-                if profile_dir_usable:
-                    context = await p.chromium.launch_persistent_context(
-                        user_data_dir, headless=config.HEADLESS_PLAYWRIGHT,
-                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
-                        user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36",
-                        slow_mo=150
-                    )
-                else:
-                    logger.warning("Using non-persistent context for tweet scraping.")
-                    browser_instance_st = await p.chromium.launch(
-                        headless=config.HEADLESS_PLAYWRIGHT,
-                        args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
-                        slow_mo=150
-                    )
-                    context = await browser_instance_st.new_context(
-                        user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
-                    )
-                context_manager = context
-                page = await context_manager.new_page()
-
-                url = f"https://x.com/{username_queried.lstrip('@')}/with_replies"
-                logger.info(f"Navigating to Twitter profile: {url}")
-                await page.goto(url, timeout=60000, wait_until="domcontentloaded")
-
-                try:
-                    await page.wait_for_selector("article[data-testid='tweet']", timeout=30000)
-                    logger.info("Initial tweet articles detected on page.")
-                except PlaywrightTimeoutError:
-                    logger.warning(f"Timed out waiting for initial tweet articles for @{username_queried}. Page might be empty or blocked."); return []
-
-                max_scroll_attempts = limit + 15
-                for scroll_attempt in range(max_scroll_attempts):
-                    if len(tweets_collected) >= limit: break
-
-                    try:
-                        clicked_count = await page.evaluate(JS_EXPAND_SHOWMORE_TWITTER, 5)
-                        if clicked_count > 0:
-                            logger.info(f"Clicked {clicked_count} 'Show more' elements on Twitter page.");
-                            await asyncio.sleep(random.uniform(0.5, 2.0))
-                    except PlaywrightTimeoutError: # More specific error for JS execution timeout
-                        logger.warning(f"Timeout during JS 'Show More' execution for @{username_queried}.")
-                    except Exception as e_sm:
-                        logger.warning(f"JavaScript 'Show More' execution error: {e_sm}")
-
-                    extracted_this_round: List[Dict[str, Any]] = []
-                    newly_added_count = 0
-                    try:
-                        extracted_this_round = await page.evaluate(JS_EXTRACT_TWEETS_TWITTER)
-                    except PlaywrightTimeoutError: # More specific error for JS execution timeout
-                        logger.warning(f"Timeout during JS tweet extraction for @{username_queried}.")
-                    except Exception as e_js:
-                        logger.error(f"JavaScript tweet extraction (JS_EXTRACT_TWEETS_TWITTER) error: {e_js}")
-
-                    for data in extracted_this_round:
-                        uid_parts = [
-                            str(data.get('id', '')),
-                            str(data.get("username","")),
-                            str(data.get("content") or "")[:30],
-                            str(data.get("timestamp",""))
-                        ]
-                        uid = hashlib.md5("".join(filter(None, uid_parts)).encode('utf-8')).hexdigest()
-
-
-                        if uid and uid not in seen_tweet_ids:
-                            tweet = TweetData(
-                                id=data.get('id', ''),
-                                username=data.get('username', 'unknown_user'),
-                                content=data.get('content', ''),
-                                timestamp=data.get('timestamp', ''),
-                                tweet_url=data.get('tweet_url', ''),
-                                is_repost=data.get('is_repost', False),
-                                reposted_by=data.get('reposted_by'),
-                                image_urls=data.get('image_urls', []),
-                                alt_texts=data.get('alt_texts', [])
-                            )
-                            tweets_collected.append(tweet)
-                            seen_tweet_ids.add(uid)
-                            newly_added_count +=1
-                            if progress_callback:
-                                try:
-                                    await progress_callback(f"Scraped {len(tweets_collected)}/{limit} tweets for @{username_queried}...")
-                                except Exception as e_cb:
-                                    logger.warning(f"Progress callback error: {e_cb}")
-                            if len(tweets_collected) >= limit: break
-
-                    if newly_added_count == 0 and scroll_attempt > (limit // 2 + 7): # Increased patience slightly
-                        logger.info("No new unique tweets found in several scroll attempts. Stopping.")
-                        if progress_callback:
-                            await progress_callback(f"Stopping early: No new unique tweets found after {scroll_attempt + 1} scrolls. Collected {len(tweets_collected)}.")
-                        break
-
-                    # Scroll down to load more tweets
-                    try:
-                        await page.evaluate("window.scrollBy(0, window.innerHeight * 1);")
-                        await asyncio.sleep(random.uniform(0.5, 2.0))
-                    except PlaywrightTimeoutError:
-                        logger.warning(f"Timeout during page scroll for @{username_queried}. Assuming end of content or page issue.")
-                        break # Stop scrolling if it times out
-
-    except PlaywrightTimeoutError as e:
-        logger.warning(f"Playwright overall timeout during tweet scraping for @{username_queried}: {e}")
-        if progress_callback:
-            await progress_callback(f"Tweet scraping for @{username_queried} timed out overall. Collected {len(tweets_collected)}.")
-    except Exception as e:
-        logger.error(f"Unexpected error during tweet scraping for @{username_queried}: {e}", exc_info=True)
-        if progress_callback:
-            await progress_callback(f"An unexpected error occurred while scraping tweets for @{username_queried}. Collected {len(tweets_collected)}.")
-    finally:
-        await _graceful_close_playwright(
+    if page:
+        await _scrape_twitter_page(
             page,
-            context_manager,
-            browser_instance_st,
-            profile_dir_usable,
+            username_queried,
+            limit,
+            progress_callback,
+            tweets_collected,
+            seen_tweet_ids,
         )
+    else:
+        user_data_dir = os.path.join(os.getcwd(), ".pw-profile")
+        profile_dir_usable = True
+        if not os.path.exists(user_data_dir):
+            try:
+                os.makedirs(user_data_dir, exist_ok=True)
+            except OSError:
+                profile_dir_usable = False
+                logger.error("Could not create .pw-profile. Using non-persistent context.")
+
+        context_manager: Optional[Any] = None
+        browser_instance_st: Optional[Any] = None
+        local_page: Optional[Any] = None
+        try:
+            async with PLAYWRIGHT_SEM:
+                async with async_playwright() as p:
+                    if profile_dir_usable:
+                        context = await p.chromium.launch_persistent_context(
+                            user_data_dir,
+                            headless=config.HEADLESS_PLAYWRIGHT,
+                            args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                            user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36",
+                            slow_mo=150,
+                        )
+                    else:
+                        browser_instance_st = await p.chromium.launch(
+                            headless=config.HEADLESS_PLAYWRIGHT,
+                            args=["--disable-blink-features=AutomationControlled", "--no-sandbox", "--disable-dev-shm-usage"],
+                            slow_mo=150,
+                        )
+                        context = await browser_instance_st.new_context(
+                            user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36"
+                        )
+                    context_manager = context
+                    local_page = await context_manager.new_page()
+                    await _scrape_twitter_page(
+                        local_page,
+                        username_queried,
+                        limit,
+                        progress_callback,
+                        tweets_collected,
+                        seen_tweet_ids,
+                    )
+        except PlaywrightTimeoutError as e:
+            logger.warning(
+                f"Playwright overall timeout for @{username_queried}: {e}"
+            )
+        except Exception as e:
+            logger.error(
+                f"Unexpected error scraping @{username_queried}: {e}", exc_info=True
+            )
+        finally:
+            await _graceful_close_playwright(
+                local_page,
+                context_manager,
+                browser_instance_st,
+                profile_dir_usable,
+            )
 
     tweets_collected.sort(key=lambda x: x.timestamp, reverse=True)
-    logger.info(f"Finished scraping. Collected {len(tweets_collected)} unique tweets for @{username_queried}.")
+    logger.info(
+        f"Finished scraping. Collected {len(tweets_collected)} unique tweets for @{username_queried}."
+    )
     return tweets_collected[:limit]
 
 


### PR DESCRIPTION
…sion, making it more efficient.

Previously, the command opened and closed a new browser for each Twitter account it scraped. This was inefficient and could lead to performance issues or rate limiting.

I've updated the scraping logic to improve this:

-   In `discord_commands.py`, I updated the `alltweets_slash_command` to manage a single browser session. It now launches one browser instance at the start and ensures it's closed properly at the end.
-   I modified the logic to create and reuse a single browser page for scraping all users, which significantly reduces overhead.
-   I updated the `process_twitter_user` function to accept an optional `page` object to make this reuse possible.
-   I also refactored the `scrape_latest_tweets` function in `web_utils.py` to support this change. It can now use a provided browser page or create its own, which maintains compatibility with the `/gettweets` command that still requires a single-use session.