### PR TITLE
feat: Add Flex processing support and timeout

### DIFF
--- a/config.py
+++ b/config.py
@@ -87,6 +87,9 @@ class Config:
             "VISION_LLM_USE_RESPONSES_API", self.USE_RESPONSES_API
         )
         self.LLM_STREAMING = _get_bool("LLM_STREAMING", True)
+        self.LLM_REQUEST_TIMEOUT_SECONDS = _get_float(
+            "LLM_REQUEST_TIMEOUT_SECONDS", 900.0
+        )
 
         # Whisper ASR model settings
         self.WHISPER_DEVICE = os.getenv("WHISPER_DEVICE") # e.g. "cuda", "cpu". None for auto-detect
@@ -101,6 +104,10 @@ class Config:
         self.RESPONSES_SERVICE_TIER = _get_choice(
             "RESPONSES_SERVICE_TIER",
             {"auto", "default", "flex", "priority"},
+        )
+        self.CHAT_COMPLETIONS_SERVICE_TIER = _get_choice(
+            "CHAT_COMPLETIONS_SERVICE_TIER",
+            {"auto", "flex"},
         )
         self.SYSTEM_PROMPT_FILE = os.getenv("SYSTEM_PROMPT_FILE", "system_prompt.md")
 

--- a/main_bot.py
+++ b/main_bot.py
@@ -42,6 +42,7 @@ bot = commands.Bot(command_prefix=commands.when_mentioned_or("!"), intents=inten
 llm_client = AsyncOpenAI(
     base_url=config.LOCAL_SERVER_URL,
     api_key=config.LLM_API_KEY or "lm-studio",
+    timeout=config.LLM_REQUEST_TIMEOUT_SECONDS,
 )  # api_key can be anything for local LLMs usually
 
 # Bot State Manager


### PR DESCRIPTION
This commit introduces support for OpenAI's Flex processing tier, providing lower costs in exchange for slower response times.

Key changes:
- Adds a configurable `LLM_REQUEST_TIMEOUT_SECONDS` to the OpenAI client, defaulting to 15 minutes to accommodate longer processing times with Flex.
- Adds `CHAT_COMPLETIONS_SERVICE_TIER` and uses the existing `RESPONSES_SERVICE_TIER` to allow setting the `service_tier` to `flex` for both Chat Completions and Responses APIs.
- Implements a fallback mechanism in `openai_api.py`. If an API call with `service_tier="flex"` fails with a `RateLimitError` (indicating resource unavailability), it automatically retries the request once with `service_tier="auto"`.