### PR TITLE
Fix(discord): Use safe followup send in gettweets command

### DIFF
--- a/discord_commands.py
+++ b/discord_commands.py
@@ -2160,7 +2160,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
                     else:
                         await progress_message.edit(content=None, embed=embed)
                 else:
-                    await interaction.followup.send(embed=embed)
+                    await safe_followup_send(interaction, embed=embed)
 
             user_query_content_for_summary = (
                 f"Please analyze and summarize the main themes, topics discussed, and overall sentiment "


### PR DESCRIPTION
The `gettweets_slash_command` was failing with a `401 Unauthorized (error code: 50027): Invalid Webhook Token` error when attempting to send a multi-part follow-up message. This occurred because it was using a direct `interaction.followup.send` call, which does not handle cases where the interaction token expires.

This change replaces the direct call with the existing `safe_followup_send` utility function. This function correctly handles the expired token exception by falling back to sending a new message to the channel, providing the intended "flex failover" behavior and preventing the command from crashing.