### PR TITLE
fix: Add explicit quote normalization to TTS cleaning

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -102,6 +102,13 @@ def clean_text_for_tts(text: str) -> str:
     if not text:
         return ""
 
+    # Explicitly replace directional quotes and backticks first for robustness.
+    text = text.replace('’', "'")  # Right single quote
+    text = text.replace('‘', "'")  # Left single quote
+    text = text.replace('“', '"')  # Left double quote
+    text = text.replace('”', '"')  # Right double quote
+    text = text.replace('`', "'")  # Backtick
+
     # 1. Normalize unicode characters to their closest ASCII equivalents.
     # NFKC is aggressive and handles many "compatibility" characters like smart quotes.
     text = unicodedata.normalize('NFKC', text)


### PR DESCRIPTION
This commit adds explicit character replacements to the `clean_text_for_tts` function to ensure that all variants of single quotes, double quotes, and backticks are normalized to their standard ASCII equivalents.

This change was made to address an issue where non-standard quote characters were breaking the Text-to-Speech (TTS) generation. While `unicodedata.normalize('NFKC', ...)` should handle this, adding explicit replacements provides a more robust and guaranteed solution.