### PR TITLE
Fix unhandled exception in `allrss` command error handler

### DIFF
--- a/discord_commands.py
+++ b/discord_commands.py
@@ -1880,7 +1880,7 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             combined_total = "\n\n".join(batch_summaries)
         except Exception as e:
             logger.error(f"Error in allrss_slash_command: {e}", exc_info=True)
-            await interaction.followup.send(content=f"Failed to process RSS feeds. Error: {str(e)[:500]}")
+            await safe_followup_send(interaction, content=f"Failed to process RSS feeds. Error: {str(e)[:500]}")
         finally:
             if acquired_lock:
                 scrape_lock.release()


### PR DESCRIPTION
The `allrss_slash_command` could fail with an unhandled `HTTPException: 401 Unauthorized` if an initial API call (like `message.edit`) failed and the interaction token expired before the error could be reported.

This was happening because the `except` block was using the raw `interaction.followup.send` instead of the provided `safe_followup_send` utility, which is designed to fall back to a regular channel message when the interaction token is no longer valid.

This change replaces the direct API call with the safe utility function to ensure error messages are always sent correctly, preventing the command from crashing.