### PR TITLE
Add manual pruning and collection metrics commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,16 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
         1.  Calls `BotState.clear_channel_history()` for the current channel ID.
     *   **Output:** An ephemeral message confirming that the short-term history for the channel has been cleared.
 
+*   **`/pruneitems <limit>`**
+    *   **Purpose:** Summarizes and prunes the oldest `limit` chat history entries into the timeline summary collection.
+    *   **Arguments:** `limit` (Required): Number of oldest entries to process.
+    *   **Output:** An ephemeral message indicating how many documents were pruned.
+
+*   **`/dbcounts`**
+    *   **Purpose:** Displays the number of documents stored in each ChromaDB collection.
+    *   **Arguments:** None.
+    *   **Output:** An ephemeral message listing each collection and its count.
+
 ---
 
 ## 9. Running the Bot

--- a/rag_chroma_manager.py
+++ b/rag_chroma_manager.py
@@ -1329,3 +1329,31 @@ async def remove_full_conversation_references(pruned_doc_ids: List[str], batch_s
             logger.error(f"An error occurred during reference cleanup in batch starting at offset {offset}: {e}", exc_info=True)
 
     logger.info(f"Completed reference cleanup. Updated {updated_count} distilled document(s).")
+
+
+def get_collection_counts() -> Dict[str, int]:
+    """Return the number of documents in each initialized ChromaDB collection."""
+    if not initialize_chromadb():
+        logger.error("ChromaDB initialization failed")
+        return {}
+
+    collections = {
+        "chat_history": chat_history_collection,
+        "distilled_chat_summary": distilled_chat_summary_collection,
+        "news_summary": news_summary_collection,
+        "rss_summary": rss_summary_collection,
+        "timeline_summary": timeline_summary_collection,
+        "relation": relation_collection,
+        "observation": observation_collection,
+        "tweets": tweets_collection,
+    }
+
+    # Include entity collection if defined
+    entity_coll = globals().get("entity_collection")
+    if entity_coll is not None:
+        collections["entity"] = entity_coll
+
+    counts: Dict[str, int] = {}
+    for name, coll in collections.items():
+        counts[name] = coll.count() if coll else 0
+    return counts


### PR DESCRIPTION
## Summary
- allow manual pruning of the oldest N chat entries via `/pruneitems`
- expose ChromaDB collection counts with `/dbcounts`
- refactor timeline pruner and add helper utilities

## Testing
- `python -m py_compile timeline_pruner.py rag_chroma_manager.py discord_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1d558d49c8328a67a504cb025c9de