### PR TITLE
Show pruning summary to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ DiscordSam offers a variety of slash commands for diverse functionalities. Here'
 *   **`/pruneitems <limit>`**
     *   **Purpose:** Summarizes and prunes the oldest `limit` chat history entries into the timeline summary collection.
     *   **Arguments:** `limit` (Required): Number of oldest entries to process.
-    *   **Output:** An ephemeral message indicating how many documents were pruned.
+    *   **Output:** An ephemeral message indicating how many documents were pruned and displaying the generated summary text.
 
 *   **`/dbcounts`**
     *   **Purpose:** Displays the number of documents stored in each ChromaDB collection.

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -2784,9 +2784,11 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
     ):
         await interaction.response.defer(thinking=True, ephemeral=True)
         try:
-            pruned = await prune_oldest_items(limit)
+            pruned, summaries = await prune_oldest_items(limit)
+            summary_text = "\n\n".join(summaries) if summaries else "No summary generated."
             await interaction.followup.send(
-                f"Pruned {pruned} documents from chat history.", ephemeral=True
+                f"Pruned {pruned} documents from chat history.\nSummary:\n{summary_text}",
+                ephemeral=True,
             )
         except Exception as e:
             logger.error(f"Error in pruneitems_slash_command: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- return pruning summaries from timeline pruner
- display summary text when using `/pruneitems`
- document prune command response

## Testing
- `python -m py_compile timeline_pruner.py discord_commands.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1db7eb6108328b5fda5c1233c1c22