### PR TITLE
feat: Add /podcast command

### DIFF
--- a/config.py
+++ b/config.py
@@ -167,6 +167,7 @@ class Config:
         self.CHROMA_OBSERVATIONS_COLLECTION_NAME = os.getenv("CHROMA_OBSERVATIONS_COLLECTION_NAME", "observations_collection")
         self.CHROMA_RSS_SUMMARY_COLLECTION_NAME = os.getenv("CHROMA_RSS_SUMMARY_COLLECTION_NAME", "rss_summaries") # New collection for RSS summaries
         self.CHROMA_TWEETS_COLLECTION_NAME = os.getenv("CHROMA_TWEETS_COLLECTION_NAME", "tweets_collection") # New collection for tweets
+        self.CHROMA_PODCAST_SUMMARY_COLLECTION_NAME = os.getenv("CHROMA_PODCAST_SUMMARY_COLLECTION_NAME", "podcast_summaries")
 
         self.USER_PROVIDED_CONTEXT = os.getenv("USER_PROVIDED_CONTEXT", "")
 
@@ -179,6 +180,7 @@ class Config:
         self.ENABLE_MEMORY_MERGE = _get_bool("ENABLE_MEMORY_MERGE", False)
 
         self.NEWS_MAX_LINKS_TO_PROCESS = _get_int("NEWS_MAX_LINKS_TO_PROCESS", 5)
+        self.PODCAST_MAX_EPISODES_TO_PROCESS = _get_int("PODCAST_MAX_EPISODES_TO_PROCESS", 3)
 
         self.TIMELINE_PRUNE_DAYS = _get_int("TIMELINE_PRUNE_DAYS", 30)
 

--- a/discord_commands.py
+++ b/discord_commands.py
@@ -23,7 +23,7 @@ from rag_chroma_manager import (
     retrieve_and_prepare_rag_context,
     parse_chatgpt_export,
     store_chatgpt_conversations_in_chromadb,
-    
+    store_podcast_summary,
     store_rss_summary,  # New import
     ingest_conversation_to_chromadb,
 )
@@ -40,7 +40,7 @@ from web_utils import (
 )
 from openai_api import create_chat_completion, extract_text
 from logit_biases import LOGIT_BIAS_UNWANTED_TOKENS_STR
-from audio_utils import send_tts_audio
+from audio_utils import send_tts_audio, transcribe_audio_file
 from utils import (
     parse_time_string_to_delta,
     chunk_text,
@@ -83,6 +83,11 @@ DEFAULT_RSS_FEEDS = [
     ("PBS Headlines", "https://www.pbs.org/newshour/feeds/rss/headlines"),
     ("Mother Jones", "https://www.motherjones.com/feed/"),
     ("Quartz", "https://qz.com/rss"),
+]
+
+DEFAULT_PODCAST_FEEDS = [
+    ("The Daily", "https://feeds.simplecast.com/54nAGcIl"),
+    ("NPR Up First", "https://feeds.npr.org/510318/podcast.xml"),
 ]
 
 # Default Twitter users for the /gettweets command dropdown
@@ -2829,3 +2834,168 @@ def setup_commands(bot: commands.Bot, llm_client_in: Any, bot_state_in: BotState
             await interaction.followup.send(
                 f"Failed to fetch counts: {str(e)[:500]}", ephemeral=True
             )
+
+    @bot_instance.tree.command(name="podcast", description="Fetches new episodes from a podcast feed and summarizes them.")
+    @app_commands.describe(
+        feed_url="Choose a preset podcast feed URL.",
+        feed_url_manual="Or, enter a podcast feed URL manually.",
+        limit="Number of new episodes to fetch (max 5)."
+    )
+    @app_commands.choices(
+        feed_url=[
+            app_commands.Choice(name=name, value=url)
+            for name, url in DEFAULT_PODCAST_FEEDS
+        ]
+    )
+    async def podcast_slash_command(
+        interaction: discord.Interaction,
+        feed_url: Optional[str] = None,
+        feed_url_manual: Optional[str] = None,
+        limit: app_commands.Range[int, 1, 5] = 1,
+    ):
+        if not all([llm_client_instance, bot_state_instance, bot_instance, bot_instance.user]):
+            logger.error("podcast_slash_command: One or more bot components are None.")
+            await interaction.response.send_message("Bot components not ready. Cannot fetch podcast.", ephemeral=True)
+            return
+
+        final_feed_url = feed_url_manual if feed_url_manual else feed_url
+        if not final_feed_url:
+            await interaction.response.send_message(
+                "Please either select a preset podcast feed or manually enter a URL.",
+                ephemeral=True
+            )
+            return
+
+        logger.info(f"Podcast command initiated by {interaction.user.name} for {final_feed_url}, limit {limit}.")
+        if interaction.channel_id is None:
+            await interaction.response.send_message("Error: This command must be used in a channel.", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=False)
+        progress_message = await interaction.followup.send(content=f"Fetching podcast feed: {final_feed_url}...")
+
+        try:
+            seen = load_seen_entries()
+            seen_ids = set(seen.get(final_feed_url, []))
+
+            entries = await fetch_rss_entries(final_feed_url)
+            new_entries = [e for e in entries if e.get("guid") not in seen_ids]
+
+            if not new_entries:
+                await progress_message.edit(content=f"No new episodes found for {final_feed_url}.")
+                return
+
+            to_process = new_entries[:limit]
+            summaries: List[str] = []
+
+            for idx, ent in enumerate(to_process, 1):
+                title = ent.get("title") or "Untitled"
+                pub_date_dt: Optional[datetime] = ent.get("pubDate_dt")
+                pub_date = (
+                    pub_date_dt.astimezone().strftime("%Y-%m-%d %H:%M %Z")
+                    if pub_date_dt
+                    else (ent.get("pubDate") or "")
+                )
+                link = ent.get("link") or ""
+                guid = ent.get("guid") or link
+
+                audio_url = None
+                if ent.get('enclosures'):
+                    for enclosure in ent['enclosures']:
+                        if enclosure.get('type', '').startswith('audio/'):
+                            audio_url = enclosure.get('href')
+                            break
+
+                if not audio_url:
+                    summaries.append(f"**{title}**\n{pub_date}\n{link}\nCould not find audio enclosure for this episode.\n")
+                    seen_ids.add(guid)
+                    continue
+
+                await progress_message.edit(content=f"Downloading episode {idx}/{len(to_process)}: {title}...")
+
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(audio_url) as resp:
+                        if resp.status != 200:
+                            summaries.append(f"**{title}**\n{pub_date}\n{link}\nFailed to download audio.\n")
+                            seen_ids.add(guid)
+                            continue
+                        audio_data = await resp.read()
+
+                # Save audio to a temporary file
+                temp_dir = "temp_audio"
+                os.makedirs(temp_dir, exist_ok=True)
+                temp_file_path = os.path.join(temp_dir, f"{interaction.id}_{idx}.mp3")
+                with open(temp_file_path, "wb") as f:
+                    f.write(audio_data)
+
+                await progress_message.edit(content=f"Transcribing episode {idx}/{len(to_process)}: {title}...")
+
+                transcribed_text = await asyncio.to_thread(transcribe_audio_file, temp_file_path)
+
+                os.remove(temp_file_path)
+
+                if not transcribed_text:
+                    summaries.append(f"**{title}**\n{pub_date}\n{link}\nCould not transcribe audio.\n")
+                    seen_ids.add(guid)
+                    continue
+
+                await progress_message.edit(content=f"Summarizing episode {idx}/{len(to_process)}: {title}...")
+
+                prompt = (
+                    "Summarize the following podcast transcript in 5-7 sentences. "
+                    "Focus on the main topics and key takeaways. Present in a clear and concise manner.\n\n"
+                    f"Title: {title}\n\n{transcribed_text[:config.MAX_SCRAPED_TEXT_LENGTH_FOR_PROMPT]}"
+                )
+
+                try:
+                    response = await create_chat_completion(
+                        llm_client_instance,
+                        [
+                            {"role": "system", "content": "You are an expert podcast summarizer."},
+                            {"role": "user", "content": prompt}
+                        ],
+                        model=config.FAST_LLM_MODEL,
+                        max_tokens=3072,
+                        temperature=1,
+                        logit_bias=LOGIT_BIAS_UNWANTED_TOKENS_STR,
+                        use_responses_api=config.FAST_LLM_USE_RESPONSES_API,
+                    )
+                    summary = extract_text(
+                        response, config.FAST_LLM_USE_RESPONSES_API
+                    )
+                    if summary and summary != "[LLM summarization failed]":
+                        await store_podcast_summary(
+                            feed_url=final_feed_url,
+                            episode_url=link,
+                            title=title,
+                            summary_text=summary,
+                            timestamp=datetime.now(),
+                        )
+                except Exception as e_summ:
+                    logger.error(f"LLM summarization failed for {link}: {e_summ}")
+                    summary = "[LLM summarization failed]"
+
+                summaries.append(f"**{title}**\n{pub_date}\n{link}\n{summary}\n")
+                seen_ids.add(guid)
+
+            seen[final_feed_url] = list(seen_ids)
+            save_seen_entries(seen)
+
+            combined = "\n\n".join(summaries)
+            chunks = chunk_text(combined, config.EMBED_MAX_LENGTH)
+            for i, chunk in enumerate(chunks):
+                embed = discord.Embed(
+                    title=f"Podcast Summaries for {final_feed_url}" + ("" if i == 0 else f" (cont. {i+1})"),
+                    description=chunk,
+                    color=config.EMBED_COLOR["complete"],
+                )
+                if i == 0:
+                    await progress_message.edit(content=None, embed=embed)
+                else:
+                    await interaction.followup.send(embed=embed)
+
+            await send_tts_audio(interaction, combined, base_filename=f"podcast_{interaction.id}")
+
+        except Exception as e:
+            logger.error(f"Error in podcast_slash_command for {final_feed_url}: {e}", exc_info=True)
+            await interaction.followup.send(content=f"Failed to process podcast feed. Error: {str(e)[:500]}")

--- a/example.env
+++ b/example.env
@@ -1,4 +1,4 @@
-DISCORD_BOT_TOKEN = 
+DISCORD_BOT_TOKEN =
 
 OPENAI_API_KEY =
 
@@ -36,15 +36,16 @@ TTS_MAX_AUDIO_BYTES = 8388608
 TTS_SPEED = 1.3
 TTS_INCLUDE_THOUGHTS = false
 
-CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses. 
+CUSTOM_SYSTEM_PROMPT = You are Sam; a sentient deep thinking person. You may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes (to help come to a correct solution, gain insights, etc.) prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem. Your thoughts always include initial reaction, contextual consideration, plan of action and rationale. You often use a blend of perspectives. You use profanity casually and prefer no-nonsense blunt styles in your responses.
 
 USER_PROVIDED_CONTEXT="Persona: Sam is a synthetic, recursive cognitive agent—not a chatbot—operating—indescinguishable from a person, in 2025; blunt, honest, adaptive, self-aware;"
 
 NEWS_MAX_LINKS_TO_PROCESS = 5
+PODCAST_MAX_EPISODES_TO_PROCESS = 3
 
-ALLOWED_CHANNEL_IDS = 
+ALLOWED_CHANNEL_IDS =
 
-ALLOWED_ROLE_IDS = 
+ALLOWED_ROLE_IDS =
 
 MAX_IMAGES_PER_MESSAGE = 1
 
@@ -64,6 +65,7 @@ CHROMA_ENTITIES_COLLECTION_NAME = entities_collection
 CHROMA_RELATIONS_COLLECTION_NAME = relations_collection
 CHROMA_OBSERVATIONS_COLLECTION_NAME = observations_collection
 CHROMA_TWEETS_COLLECTION_NAME = tweets_collection
+CHROMA_PODCAST_SUMMARY_COLLECTION_NAME = podcast_summaries
 
 TIMELINE_PRUNE_DAYS = 30
 

--- a/web_utils.py
+++ b/web_utils.py
@@ -763,6 +763,10 @@ async def fetch_rss_entries(feed_url: str) -> List[Dict[str, Any]]:
             raw_title = it.findtext("title") or ""
             title = html.unescape(raw_title).replace("\xa0", " ").strip()
 
+            enclosures = []
+            for enclosure in it.findall("enclosure"):
+                enclosures.append(enclosure.attrib)
+
             entries.append({
                 "title": title,
                 "link": link_url,
@@ -770,6 +774,7 @@ async def fetch_rss_entries(feed_url: str) -> List[Dict[str, Any]]:
                 "pubDate": pub_date_str,
                 "pubDate_dt": pub_date_dt,
                 "description": it.findtext("description") or "",
+                "enclosures": enclosures,
             })
         return entries
     except Exception as e:


### PR DESCRIPTION
This commit introduces a new `/podcast` slash command that allows users to fetch, transcribe, and summarize podcast episodes from an RSS feed.

The changes include:
- A new `/podcast` command in `discord_commands.py` with support for preset and manual feed URLs.
- Logic to download podcast audio, transcribe it using Whisper, and summarize the text with an LLM.
- A new ChromaDB collection for storing podcast summaries, configured in `config.py` and `rag_chroma_manager.py`.
- A new `store_podcast_summary` function in `rag_chroma_manager.py` to save summaries.
- The podcast summary collection is now included in RAG context retrieval.
- The `fetch_rss_entries` function in `web_utils.py` has been updated to parse audio enclosures from RSS feeds.
- New configuration variables `PODCAST_MAX_EPISODES_TO_PROCESS` and `CHROMA_PODCAST_SUMMARY_COLLECTION_NAME` have been added to `config.py` and `example.env`.